### PR TITLE
WIP: Add pass-through Fastly property for voter registration flow.

### DIFF
--- a/main.tf
+++ b/main.tf
@@ -105,6 +105,12 @@ module "dosomething-qa" {
   papertrail_destination_fastly_qa  = "${var.papertrail_destination_fastly_qa}"
 }
 
+# The voter registration landing page <vote.dosomething.org>
+# is hosted on Instapage, with optional fallback to S3.
+module "vote" {
+  source = "vote"
+}
+
 # The voting application (https://git.io/fAsod) once hosted
 # voting campaigns like Celebs Gone Good & Athletes Gone Good.
 module "voting-app" {

--- a/vote/custom.vcl
+++ b/vote/custom.vcl
@@ -11,10 +11,19 @@
 # ------------------------------------------------------------------------------------
 #
 table redirects {
-  # original path -> target URL
-  "/direct":
-  "https://register.rockthevote.com/registrants/new?partner=37187&source=[r]",
+  # example redirect. format: path -> target URL
+  "/direct": "https://register.rockthevote.com/registrants/new?partner=37187&source=[r]",
+
+  # partner/ad direct redirects <https://goo.gl/LKPofK>:
   "/katiecouric": "https://register.rockthevote.com/registrants/new?partner=37187&source=campaignID:8017,campaignRunID:8022,source:influencer,source_details:katie_couric"
+  # "/g/1": "https://register.rockthevote.com/registrants/new?partner=37187&source=ads",
+  # "/g/2": "https://register.rockthevote.com/registrants/new?partner=37187&source=ads",
+  # "/f/1": "https://register.rockthevote.com/registrants/new?partner=37187",
+  # "/s/1": "https://register.rockthevote.com/registrants/new?partner=37187",
+  # "/nationalschoolwalkout": "https://register.rockthevote.com/registrants/new?partner=37187&source=campaignID:8017,campaignRunID:8022,source:partner,source_details:NSW",
+  # "/dmv": "https://register.rockthevote.com/registrants/new?partner=37187&source=campaignID:8017,campaignRunID:8022,source:partner,source_details:dmv_email",
+  # "/johnlegend": "https://register.rockthevote.com/registrants/new?partner=37187&source=campaignID:8017,campaignRunID:8022,source:influencer,source_details:john_legend",
+  # "/ehjovan": "https://register.rockthevote.com/registrants/new?partner=37187&source=campaignID:8017,campaignRunID:8022,source:influencer,source_details:jovan",
 }
 
 sub vcl_recv {

--- a/vote/custom.vcl
+++ b/vote/custom.vcl
@@ -15,7 +15,7 @@ table redirects {
   "/direct": "https://register.rockthevote.com/registrants/new?partner=37187&source=[r]",
 
   # partner/ad direct redirects <https://goo.gl/LKPofK>:
-  "/katiecouric": "https://register.rockthevote.com/registrants/new?partner=37187&source=campaignID:8017,campaignRunID:8022,source:influencer,source_details:katie_couric"
+  # "/katiecouric": "https://register.rockthevote.com/registrants/new?partner=37187&source=campaignID:8017,campaignRunID:8022,source:influencer,source_details:katie_couric",
   # "/g/1": "https://register.rockthevote.com/registrants/new?partner=37187&source=ads",
   # "/g/2": "https://register.rockthevote.com/registrants/new?partner=37187&source=ads",
   # "/f/1": "https://register.rockthevote.com/registrants/new?partner=37187",

--- a/vote/custom.vcl
+++ b/vote/custom.vcl
@@ -12,7 +12,9 @@
 #
 table redirects {
   # original path -> target URL
-  "/direct": "https://register.rockthevote.com/registrants/new?partner=37187&source=[r]"
+  "/direct":
+  "https://register.rockthevote.com/registrants/new?partner=37187&source=[r]",
+  "/katiecouric": "https://register.rockthevote.com/registrants/new?partner=37187&source=campaignID:8017,campaignRunID:8022,source:influencer,source_details:katie_couric"
 }
 
 sub vcl_recv {

--- a/vote/custom.vcl
+++ b/vote/custom.vcl
@@ -1,0 +1,118 @@
+#
+# This is a custom VCL for this property, since Terraform does
+# not support Fastly's VCL snippets yet. <https://git.io/fAU5g> 
+# 
+# See Fastly's VCL boilerplate & documentation here:
+# <https://docs.fastly.com/vcl/custom-vcl/creating-custom-vcl/>
+#
+
+# ------------------------------------------------------------------------------------
+# Snippet: Redirects (INIT)
+# ------------------------------------------------------------------------------------
+#
+table redirects {
+  # original path -> target URL
+  "/direct": "https://register.rockthevote.com/registrants/new?partner=37187&source=[r]"
+}
+
+sub vcl_recv {
+#FASTLY recv
+  # ------------------------------------------------------------------------------------
+  # Snippet: Trigger Redirects
+  # ------------------------------------------------------------------------------------
+  if (table.lookup(redirects, std.tolower(req.url.path))) {
+    error 700 "Moved";
+  }
+  # ------------------------------------------------------------------------------------
+
+  if (req.request != "HEAD" && req.request != "GET" && req.request != "FASTLYPURGE") {
+    return(pass);
+  }
+
+  return(lookup);
+}
+
+sub vcl_fetch {
+#FASTLY fetch
+  if ((beresp.status == 500 || beresp.status == 503) && req.restarts < 1 && (req.request == "GET" || req.request == "HEAD")) {
+    restart;
+  }
+
+  if (req.restarts > 0) {
+    set beresp.http.Fastly-Restarts = req.restarts;
+  }
+
+  if (beresp.http.Set-Cookie) {
+    set req.http.Fastly-Cachetype = "SETCOOKIE";
+    return(pass);
+  }
+
+  if (beresp.http.Cache-Control ~ "private") {
+    set req.http.Fastly-Cachetype = "PRIVATE";
+    return(pass);
+  }
+
+  if (beresp.status == 500 || beresp.status == 503) {
+    set req.http.Fastly-Cachetype = "ERROR";
+    set beresp.ttl = 1s;
+    set beresp.grace = 5s;
+    return(deliver);
+  }
+
+  if (beresp.http.Expires || beresp.http.Surrogate-Control ~ "max-age" || beresp.http.Cache-Control ~ "(s-maxage|max-age)") {
+    # keep the ttl here
+  } else {
+    # apply the default ttl
+    set beresp.ttl = 3600s;
+  }
+
+  return(deliver);
+}
+
+sub vcl_hit {
+#FASTLY hit
+
+  if (!obj.cacheable) {
+    return(pass);
+  }
+  return(deliver);
+}
+
+sub vcl_miss {
+#FASTLY miss
+  return(fetch);
+}
+
+sub vcl_deliver {
+#FASTLY deliver
+  return(deliver);
+}
+
+sub vcl_error {
+#FASTLY error
+  # ------------------------------------------------------------------------------------
+  # Snippet: Handle Redirect (ERROR)
+  # ------------------------------------------------------------------------------------
+  if (obj.status == 700) {
+    declare local var.new_location STRING;
+    
+    set var.new_location = table.lookup(redirects, std.tolower(req.url.path));
+    if (subfield(req.url.qs, "r", "&"))  {
+      set var.new_location = regsub(var.new_location, "\[r\]", subfield(req.url.qs, "r", "&"));
+    }
+    
+    set obj.http.Location = var.new_location;
+    set obj.status = 302;
+  
+    return(deliver);
+  }
+  # ------------------------------------------------------------------------------------
+}
+
+sub vcl_pass {
+#FASTLY pass
+}
+
+sub vcl_log {
+#FASTLY log
+}

--- a/vote/main.tf
+++ b/vote/main.tf
@@ -1,3 +1,7 @@
+variable "s3_routes" {
+  default = "^/(static|vendor)"
+}
+
 resource "fastly_service_v1" "vote" {
   name          = "Terraform: Voter Registration"
   force_destroy = true
@@ -28,7 +32,19 @@ resource "fastly_service_v1" "vote" {
   condition {
     type      = "REQUEST"
     name      = "backend-s3"
-    statement = "req.url ~ \"^/(static|vendor)\""
+    statement = "req.url ~ \"${var.s3_routes}\""
+  }
+
+  condition {
+    type      = "CACHE"
+    name      = "cache-not-s3"
+    statement = "req.url !~ \"${var.s3_routes}\""
+  }
+
+  cache_setting {
+    name            = "force-pass"
+    action          = "pass"
+    cache_condition = "cache-not-s3"
   }
 
   gzip {

--- a/vote/main.tf
+++ b/vote/main.tf
@@ -6,6 +6,10 @@ resource "fastly_service_v1" "vote" {
     name = "vote-fastly.dosomething.org"
   }
 
+  domain {
+    name = "vote.dosomething.org"
+  }
+
   default_host = "vote.dosomething.org"
 
   backend {

--- a/vote/main.tf
+++ b/vote/main.tf
@@ -1,0 +1,43 @@
+resource "fastly_service_v1" "vote" {
+  name          = "Terraform: Voter Registration"
+  force_destroy = true
+
+  domain {
+    name = "vote-fastly.dosomething.org"
+  }
+
+  default_host = "vote.dosomething.org"
+
+  backend {
+    name    = "instapage"
+    address = "secure.pageserve.co"
+    port    = 80
+  }
+
+  gzip {
+    name = "gzip"
+
+    extensions = ["css", "js", "html", "eot", "ico", "otf", "ttf", "json"]
+
+    content_types = [
+      "text/html",
+      "application/x-javascript",
+      "text/css",
+      "application/javascript",
+      "text/javascript",
+      "application/json",
+      "application/vnd.ms-fontobject",
+      "application/x-font-opentype",
+      "application/x-font-truetype",
+      "application/x-font-ttf",
+      "application/xml",
+      "font/eot",
+      "font/opentype",
+      "font/otf",
+      "image/svg+xml",
+      "image/vnd.microsoft.icon",
+      "text/plain",
+      "text/xml",
+    ]
+  }
+}

--- a/vote/main.tf
+++ b/vote/main.tf
@@ -40,4 +40,12 @@ resource "fastly_service_v1" "vote" {
       "text/xml",
     ]
   }
+
+  vcl {
+    main = true
+    name = "main"
+
+    # @TODO: Separate into snippets once Terraform adds support.
+    content = "${file("${path.module}/custom.vcl")}"
+  }
 }

--- a/vote/main.tf
+++ b/vote/main.tf
@@ -41,6 +41,11 @@ resource "fastly_service_v1" "vote" {
     ]
   }
 
+  request_setting {
+    name      = "Force SSL"
+    force_ssl = true
+  }
+
   vcl {
     main = true
     name = "main"

--- a/vote/policy-vote.json
+++ b/vote/policy-vote.json
@@ -1,0 +1,12 @@
+{
+  "Version":"2012-10-17",
+  "Statement":[
+    {
+      "Sid":"PublicReadGetObject",
+      "Effect":"Allow",
+      "Principal": "*",
+      "Action":["s3:GetObject"],
+      "Resource":["arn:aws:s3:::vote.dosomething.org/*"]
+    }
+  ]
+}


### PR DESCRIPTION
This pull request adds a simple pass-through property for [vote.dosomething.org](https://vote.dosomething.org).

The idea for this came out of the [pre-mortem](https://docs.google.com/document/d/1-xlVw7a6VxJY3ezh_edshjk3_mMb5fOJbGt4B7noHKk/edit) we ran last week as a way to mitigate against an Instapage failure – in a worst case scenario, we want to be able to easily route traffic to a static site or redirect directly to one of our partner's flows.

I've kept a running narrative as I made changes to this Fastly property below, and everything should be fully functional to test on [vote-fastly.dosomething.org](https://vote-fastly.dosomething.org). Here's where we've ended up so far:

### Implemented Features:
A simple [pass-through Fastly property](#issuecomment-423617063) to existing Instapage backend. This will allow us to swap our DNS for `vote.dosomething.org` to Fastly _with zero impact to how things currently work_. However, we can then use the following "in case of emergency" tactics without any downtime:
 - Overriding [a vanity URL to redirect directly](#issuecomment-423637214) to Rock The Vote (e.g. automatically sending traffic from `/katiecouric` to `https://register.rockthevote.com/...` with the appropriate hard-coded partner referral string)
 - Overriding a page to [redirect directly to Rock The Vote's flow w/ a referral query string](#issuecomment-423635409) (e.g. sending Gambit or Phoenix traffic from `vote.dosomething.org/direct?r=<source>` to `https://register.rockthevote.com/...`)
 - Replacing a page with a [static HTML copy hosted in S3](#issuecomment-423657097) – maintaining the same user experience even if Instapage's backend is on fire. We would lose Instapage's tracking (but should still have Google/Facebook analytics). This does _not_ currently support referral strings.