### PR TITLE
In case of emergency: Enable Fastly redirects.

### DIFF
--- a/vote/custom.vcl
+++ b/vote/custom.vcl
@@ -15,15 +15,15 @@ table redirects {
   "/direct": "https://register.rockthevote.com/registrants/new?partner=37187&source=[r]",
 
   # partner/ad direct redirects <https://goo.gl/LKPofK>:
-  # "/katiecouric": "https://register.rockthevote.com/registrants/new?partner=37187&source=campaignID:8017,campaignRunID:8022,source:influencer,source_details:katie_couric",
-  # "/g/1": "https://register.rockthevote.com/registrants/new?partner=37187&source=ads",
-  # "/g/2": "https://register.rockthevote.com/registrants/new?partner=37187&source=ads",
-  # "/f/1": "https://register.rockthevote.com/registrants/new?partner=37187",
-  # "/s/1": "https://register.rockthevote.com/registrants/new?partner=37187",
-  # "/nationalschoolwalkout": "https://register.rockthevote.com/registrants/new?partner=37187&source=campaignID:8017,campaignRunID:8022,source:partner,source_details:NSW",
-  # "/dmv": "https://register.rockthevote.com/registrants/new?partner=37187&source=campaignID:8017,campaignRunID:8022,source:partner,source_details:dmv_email",
-  # "/johnlegend": "https://register.rockthevote.com/registrants/new?partner=37187&source=campaignID:8017,campaignRunID:8022,source:influencer,source_details:john_legend",
-  # "/ehjovan": "https://register.rockthevote.com/registrants/new?partner=37187&source=campaignID:8017,campaignRunID:8022,source:influencer,source_details:jovan",
+  "/katiecouric": "https://register.rockthevote.com/registrants/new?partner=37187&source=campaignID:8017,campaignRunID:8022,source:influencer,source_details:katie_couric",
+  "/g/1": "https://register.rockthevote.com/registrants/new?partner=37187&source=ads",
+  "/g/2": "https://register.rockthevote.com/registrants/new?partner=37187&source=ads",
+  "/f/1": "https://register.rockthevote.com/registrants/new?partner=37187",
+  "/s/1": "https://register.rockthevote.com/registrants/new?partner=37187",
+  "/nationalschoolwalkout": "https://register.rockthevote.com/registrants/new?partner=37187&source=campaignID:8017,campaignRunID:8022,source:partner,source_details:NSW",
+  "/dmv": "https://register.rockthevote.com/registrants/new?partner=37187&source=campaignID:8017,campaignRunID:8022,source:partner,source_details:dmv_email",
+  "/johnlegend": "https://register.rockthevote.com/registrants/new?partner=37187&source=campaignID:8017,campaignRunID:8022,source:influencer,source_details:john_legend",
+  "/ehjovan": "https://register.rockthevote.com/registrants/new?partner=37187&source=campaignID:8017,campaignRunID:8022,source:influencer,source_details:jovan",
 }
 
 sub vcl_recv {


### PR DESCRIPTION
This pull request enables Fastly redirects for voter registration landing pages, e.g. sending traffic on https://vote.dosomething.org/katiecouric _directly_ to https://register.rockthevote.com/registrants/new?partner=37187&source=campaignID:8017,campaignRunID:8022,source:influencer,source_details:katie_couric.

To apply, checkout this branch and run `terraform apply`.