### PR TITLE
In case of emergency: Serve pages from S3.

### DIFF
--- a/vote/main.tf
+++ b/vote/main.tf
@@ -1,7 +1,3 @@
-variable "s3_routes" {
-  default = "^/(static|vendor)"
-}
-
 resource "fastly_service_v1" "vote" {
   name          = "Terraform: Voter Registration"
   force_destroy = true
@@ -17,34 +13,9 @@ resource "fastly_service_v1" "vote" {
   default_host = "vote.dosomething.org"
 
   backend {
-    name    = "instapage"
-    address = "secure.pageserve.co"
+    name    = "s3"
+    address = "${aws_s3_bucket.vote.bucket}.s3-website-${aws_s3_bucket.vote.region}.amazonaws.com"
     port    = 80
-  }
-
-  backend {
-    name              = "s3"
-    request_condition = "backend-s3"
-    address           = "${aws_s3_bucket.vote.bucket}.s3-website-${aws_s3_bucket.vote.region}.amazonaws.com"
-    port              = 80
-  }
-
-  condition {
-    type      = "REQUEST"
-    name      = "backend-s3"
-    statement = "req.url ~ \"${var.s3_routes}\""
-  }
-
-  condition {
-    type      = "CACHE"
-    name      = "cache-not-s3"
-    statement = "req.url !~ \"${var.s3_routes}\""
-  }
-
-  cache_setting {
-    name            = "force-pass"
-    action          = "pass"
-    cache_condition = "cache-not-s3"
   }
 
   gzip {


### PR DESCRIPTION
This pull request swaps out the backend for our vote.dosomething.org Fastly property from Instapage to a S3 bucket with static snapshots of some of our highest priority flows. This should be our first backup plan in case Instapage goes down, since it preserves the best user experience.

The snapshots can be seen on S3 at the following URLs: [/?r=…](http://vote.dosomething.org.s3-website-us-east-1.amazonaws.com/?r=test_referral), [/dmv](http://vote.dosomething.org.s3-website-us-east-1.amazonaws.com/dmv/), [/ehjovan](http://vote.dosomething.org.s3-website-us-east-1.amazonaws.com/ehjovan/), [/johnlegend](http://vote.dosomething.org.s3-website-us-east-1.amazonaws.com/johnlegend/), [/katiecouric](http://vote.dosomething.org.s3-website-us-east-1.amazonaws.com/katiecouric/), [/member-drive?userId=…&r=…](http://vote.dosomething.org.s3-website-us-east-1.amazonaws.com/member-drive?userId=59516ca6a0bfad46dd764575&r=user:59516ca6a0bfad46dd764575,campaign:7059,campaignRunID=8128,source=web,source_details=onlinedrivereferral,referral=true), and [/nationalschoolwalkout](http://vote.dosomething.org.s3-website-us-east-1.amazonaws.com/nationalschoolwalkout/). Any path without a snapshot will serve the default landing page, e.g. [/asdioajoidjasiodj](http://vote.dosomething.org.s3-website-us-east-1.amazonaws.com/asdioajoidjasiodj).

To apply, checkout this branch and run `terraform apply`.