### PR TITLE
Add some logging for errors in the voter reg property.

### DIFF
--- a/dosomething/northstar/main.tf
+++ b/dosomething/northstar/main.tf
@@ -28,7 +28,7 @@ resource "heroku_formation" "northstar" {
   app      = "${heroku_app.northstar.name}"
   type     = "web"
   size     = "Performance-M"
-  quantity = 1
+  quantity = 10
 }
 
 resource "heroku_formation" "northstar-queue" {

--- a/main.tf
+++ b/main.tf
@@ -109,6 +109,8 @@ module "dosomething-qa" {
 # is hosted on Instapage, with optional fallback to S3.
 module "vote" {
   source = "vote"
+
+  papertrail_destination = "${var.papertrail_destination_fastly}"
 }
 
 # The voting application (https://git.io/fAsod) once hosted

--- a/vote/main.tf
+++ b/vote/main.tf
@@ -1,3 +1,5 @@
+variable "papertrail_destination" {}
+
 variable "s3_routes" {
   default = "^/(static|vendor)"
 }
@@ -85,6 +87,20 @@ resource "fastly_service_v1" "vote" {
 
     # @TODO: Separate into snippets once Terraform adds support.
     content = "${file("${path.module}/custom.vcl")}"
+  }
+
+  condition {
+    type      = "RESPONSE"
+    name      = "errors"
+    statement = "resp.status > 399 && resp.status < 600"
+  }
+
+  papertrail {
+    name               = "vote.dosomething.org"
+    address            = "${element(split(":", var.papertrail_destination), 0)}"
+    port               = "${element(split(":", var.papertrail_destination), 1)}"
+    format             = "%t '%r' status=%>s bytes=%b microseconds=%D"
+    response_condition = "errors"
   }
 }
 


### PR DESCRIPTION
I noticed we're getting a few 400s on [vote.dosomething.org](https://vote.dosomething.org) when looking at [errors](https://user-images.githubusercontent.com/583202/46031689-94118080-c0c7-11e8-879f-cd1ec4c7aea1.png) in the Fastly dashboard. It's seems to scale linearly along with [successful requests](https://user-images.githubusercontent.com/583202/46031728-b6a39980-c0c7-11e8-8fc1-e14d17b4f4e6.png), and accounts for a small but noticeable chunk of traffic. I don't think it's anything to raise alarms about, but would be interesting to get more context that the dashboard doesn't give (e.g. are they 404s? 429s? what URLs?).

This pull request adds this property to our Papertrail account, and writes any 4xx or 5xx error codes to the logs. This should give us some more insight into what's going on here. The plan:

<img width="717" alt="screen shot 2018-09-25 at 1 30 45 pm" src="https://user-images.githubusercontent.com/583202/46031885-1ef27b00-c0c8-11e8-8264-2e1dda194d12.png">

