### PR TITLE
Add country code to production Fastly property.

### DIFF
--- a/dosomething/fastly/main.tf
+++ b/dosomething/fastly/main.tf
@@ -91,6 +91,22 @@ resource "fastly_service_v1" "dosomething" {
     ]
   }
 
+  header {
+    name        = "Country Code"
+    type        = "request"
+    action      = "set"
+    source      = "geoip.country_code"
+    destination = "http.X-Fastly-Country-Code"
+  }
+
+  header {
+    name        = "Country Code (Debug)"
+    type        = "response"
+    action      = "set"
+    source      = "geoip.country_code"
+    destination = "http.X-Fastly-Country-Code"
+  }
+
   request_setting {
     name      = "Force SSL"
     force_ssl = true

--- a/dosomething/northstar/main.tf
+++ b/dosomething/northstar/main.tf
@@ -28,7 +28,7 @@ resource "heroku_formation" "northstar" {
   app      = "${heroku_app.northstar.name}"
   type     = "web"
   size     = "Performance-M"
-  quantity = 10
+  quantity = 1
 }
 
 resource "heroku_formation" "northstar-queue" {


### PR DESCRIPTION
I'd accidentally dropped the `X-Fastly-Country-Code` header from the production config, which resulted in users missing their `country` attribute and therefore not getting welcome emails (flagged by Luke & Anthony [in Slack](https://dosomething.slack.com/archives/C03T8SDJW/p1537798336000100)). This affected new user registrations from 9/18 until now.

This pull request adds the `X-Fastly-Country-Code` header to requests in our production config:

<img width="888" alt="screen shot 2018-09-25 at 4 35 26 pm" src="https://user-images.githubusercontent.com/583202/46041544-0773bc00-c0e1-11e8-9027-080b3da2d7bf.png">
