### PR TITLE
Allow Facebook & Twitter to crawl QA/dev sites.

### DIFF
--- a/shared/deny-robots.txt
+++ b/shared/deny-robots.txt
@@ -1,3 +1,14 @@
+# Prevent crawlers, like Google, from
+# indexing our QA & development sites.
 User-agent:*
-
 Disallow: /
+
+# Allow Facebook & Twitter crawlers for testing.
+User-agent: Facebot
+Disallow:
+
+User-agent: facebookexternalhit
+Disallow:
+
+User-agent: Twitterbot
+Disallow:


### PR DESCRIPTION
This should fix #16 by allowing the `Facebot`, `facebookexternalhit` & `Twitterbot` user-agents to access our QA environments.

Interestingly, Facebook _was_ able to crawl the dev site when I tested without this change, but their documentation does say that they [respect `robots.txt`](https://developers.facebook.com/docs/sharing/webmasters/crawler) so it seems safer to whitelist.