### PR TITLE
Exclude Google, Facebook & Twitter bots from GDPR redirect.

### DIFF
--- a/shared/gdpr_recv.vcl
+++ b/shared/gdpr_recv.vcl
@@ -1,5 +1,6 @@
-// If the current request is coming from a country in
-// the EEA, trigger a redirect to our GDPR page.
-if (table.lookup(eea, geoip.country_code)) {
+// If the current request is coming from a country in the EEA (and is not a
+// search or social metadata crawler), trigger a redirect to our GDPR page.
+if (table.lookup(eea, geoip.country_code) &&
+  req.http.User-Agent !~ "(?i)googlebot|facebot|facebookexternalhit|twitterbot") {
   error 811;
 }


### PR DESCRIPTION
This pull request updates our GDPR snippet (references DoSomething/devops#402) to _not_ apply a redirect to web crawlers like Facebook, Twitter, or Google. This should prevent issues where users see the wrong metadata on their Facebook news feed (or worse, we lose a page in Google results)!

I've created a [Fiddle](https://fiddle.fastlydemo.net/fiddle/4e5d344d) to test this change here (with `"US"` included in the list of EEA countries so we can pretend we're in the EEA)! You can test it with various user agents using the "Headers" option right beneath the URL.

Fixes #17.