### PR TITLE
Route '/index.php' requests to Ashes.

### DIFF
--- a/dosomething-dev/fastly-frontend/ashes_recv.vcl
+++ b/dosomething-dev/fastly-frontend/ashes_recv.vcl
@@ -14,6 +14,10 @@ else if (req.url.path ~ "(?i)^\/((us|mx|br)\/?)?campaigns\/?$") {
   # The Explore Campaigns page is served by Ashes:
   set req.http.X-Fastly-Backend = "ashes";
 }
+else if (req.url.path ~ "(?i)^\/index\.php$") {
+  # The '/index.php' file is used by some Ashes admin pages:
+  set req.http.X-Fastly-Backend = "ashes";
+}
 else if (req.url.path ~ "(?i)\/((us|mx|br)\/)?(admin|image|openid\-connect|file|sites|profiles|misc|user|taxonomy|modules|search|system|themes|node|js)") {
   # Drupal built-in and third-party modules are served by Ashes:
   set req.http.X-Fastly-Backend = "ashes";

--- a/dosomething-qa/fastly-frontend/ashes_recv.vcl
+++ b/dosomething-qa/fastly-frontend/ashes_recv.vcl
@@ -14,6 +14,10 @@ else if (req.url.path ~ "(?i)^\/((us|mx|br)\/?)?campaigns\/?$") {
   # The Explore Campaigns page is served by Ashes:
   set req.http.X-Fastly-Backend = "ashes";
 }
+else if (req.url.path ~ "(?i)^\/index\.php$") {
+  # The '/index.php' file is used by some Ashes admin pages:
+  set req.http.X-Fastly-Backend = "ashes";
+}
 else if (req.url.path ~ "(?i)\/((us|mx|br)\/)?(admin|image|openid\-connect|file|sites|profiles|misc|user|taxonomy|modules|search|system|themes|node|js)") {
   # Drupal built-in and third-party modules are served by Ashes:
   set req.http.X-Fastly-Backend = "ashes";

--- a/dosomething/fastly-frontend/ashes_recv.vcl
+++ b/dosomething/fastly-frontend/ashes_recv.vcl
@@ -18,6 +18,10 @@ else if (req.url.path ~ "(?i)\/((us|mx|br)\/)?(admin|image|openid\-connect|file|
   # Drupal built-in and third-party modules are served by Ashes:
   set req.http.X-Fastly-Backend = "ashes";
 }
+else if (req.url.path ~ "(?i)^\/index\.php$") {
+  # The '/index.php' file is used by some Ashes admin pages:
+  set req.http.X-Fastly-Backend = "ashes";
+}
 else if (
   req.url.path ~ "(?i)\/((us|mx|br)\/)?(facts|fact|about|sobre|volunteer|voluntario|reportback|ds\-share\-complete|api\/v1)"
   && std.tolower(req.url.path) != "/us/about/our-press"


### PR DESCRIPTION
This pull request adds a routing rule to send `/index.php` requests to Ashes. I'd thought these we just noise from random crawlers... turns out some of Drupal's admin panel makes requests there (likely since they can't guarantee people have Apache/nginx configured to rewrite paths?)

Fixes #21.