### PR TITLE
Remove 'find-your-vspot' from Ashes.

### DIFF
--- a/dosomething-qa/fastly-frontend/ashes_init.vcl
+++ b/dosomething-qa/fastly-frontend/ashes_init.vcl
@@ -94,7 +94,6 @@ table ashes_campaigns {
   "fight-equality": "true",
   "fight-fire-cookies": "true",
   "file-under-sexist": "true",
-  "find-your-v-spot": "true",
   "fish-bowl-baggies": "true",
   "flush-it-down": "true",
   "flyer-away": "true",

--- a/dosomething/fastly-frontend/ashes_init.vcl
+++ b/dosomething/fastly-frontend/ashes_init.vcl
@@ -94,7 +94,6 @@ table ashes_campaigns {
   "fight-equality": "true",
   "fight-fire-cookies": "true",
   "file-under-sexist": "true",
-  "find-your-v-spot": "true",
   "fish-bowl-baggies": "true",
   "flush-it-down": "true",
   "flyer-away": "true",


### PR DESCRIPTION
This pull request removes `find-your-vspot` from the list of Ashes campaigns. 🗳 