### PR TITLE
WIP: Enable shielding for backend services.

### DIFF
--- a/dosomething-dev/fastly-backend/main.tf
+++ b/dosomething-dev/fastly-backend/main.tf
@@ -66,6 +66,7 @@ resource "fastly_service_v1" "backends-dev" {
     address           = "${var.graphql_backend}"
     name              = "${var.graphql_name}"
     request_condition = "backend-graphql-dev"
+    shield            = "iad-va-us"
     auto_loadbalance  = false
     port              = 443
   }
@@ -74,6 +75,7 @@ resource "fastly_service_v1" "backends-dev" {
     address           = "${var.northstar_backend}"
     name              = "${var.northstar_name}"
     request_condition = "backend-northstar-dev"
+    shield            = "iad-va-us"
     auto_loadbalance  = false
     port              = 443
   }
@@ -82,6 +84,7 @@ resource "fastly_service_v1" "backends-dev" {
     address           = "${var.phoenix_backend}"
     name              = "${var.phoenix_name}"
     request_condition = "backend-phoenix-dev"
+    shield            = "iad-va-us"
     auto_loadbalance  = false
     port              = 443
   }
@@ -90,6 +93,7 @@ resource "fastly_service_v1" "backends-dev" {
     address           = "${var.rogue_backend}"
     name              = "${var.rogue_name}"
     request_condition = "backend-rogue-dev"
+    shield            = "iad-va-us"
     auto_loadbalance  = false
     port              = 443
   }

--- a/dosomething-dev/fastly-backend/main.tf
+++ b/dosomething-dev/fastly-backend/main.tf
@@ -12,6 +12,10 @@ variable "rogue_domain" {}
 variable "rogue_backend" {}
 variable "papertrail_destination" {}
 
+variable "papertrail_log_format" {
+  default = "%t '%r' status=%>s bytes=%b microseconds=%D"
+}
+
 resource "fastly_service_v1" "backends-dev" {
   name          = "Terraform: Backends (Development)"
   force_destroy = true
@@ -39,8 +43,20 @@ resource "fastly_service_v1" "backends-dev" {
   }
 
   condition {
+    type      = "RESPONSE"
+    name      = "response-graphql-dev"
+    statement = "req.http.host == \"${var.graphql_domain}\""
+  }
+
+  condition {
     type      = "REQUEST"
     name      = "backend-northstar-dev"
+    statement = "req.http.host == \"${var.northstar_domain}\""
+  }
+
+  condition {
+    type      = "RESPONSE"
+    name      = "response-northstar-dev"
     statement = "req.http.host == \"${var.northstar_domain}\""
   }
 
@@ -51,8 +67,20 @@ resource "fastly_service_v1" "backends-dev" {
   }
 
   condition {
+    type      = "RESPONSE"
+    name      = "response-phoenix-dev"
+    statement = "req.http.host == \"${var.phoenix_domain}\""
+  }
+
+  condition {
     type      = "REQUEST"
     name      = "backend-rogue-dev"
+    statement = "req.http.host == \"${var.rogue_domain}\""
+  }
+
+  condition {
+    type      = "RESPONSE"
+    name      = "response-rogue-dev"
     statement = "req.http.host == \"${var.rogue_domain}\""
   }
 
@@ -176,59 +204,35 @@ resource "fastly_service_v1" "backends-dev" {
     content = "${file("${path.root}/shared/origin_name.vcl")}"
   }
 
-  condition {
-    type      = "RESPONSE"
-    name      = "errors-northstar-dev"
-    statement = "req.http.host == \"${var.northstar_domain}\" && resp.status > 501 && resp.status < 600"
-  }
-
   papertrail {
     name               = "northstar-dev"
     address            = "${element(split(":", var.papertrail_destination), 0)}"
     port               = "${element(split(":", var.papertrail_destination), 1)}"
     format             = "%t '%r' status=%>s bytes=%b microseconds=%D"
-    response_condition = "errors-northstar-dev"
-  }
-
-  condition {
-    type      = "RESPONSE"
-    name      = "errors-phoenix-dev"
-    statement = "req.http.host == \"${var.phoenix_domain}\" && resp.status > 501 && resp.status < 600"
+    response_condition = "response-northstar-dev"
   }
 
   papertrail {
     name               = "phoenix-dev"
     address            = "${element(split(":", var.papertrail_destination), 0)}"
     port               = "${element(split(":", var.papertrail_destination), 1)}"
-    format             = "%t '%r' status=%>s bytes=%b microseconds=%D"
-    response_condition = "errors-phoenix-dev"
-  }
-
-  condition {
-    type      = "RESPONSE"
-    name      = "errors-rogue-dev"
-    statement = "req.http.host == \"${var.rogue_domain}\" && resp.status > 501 && resp.status < 600"
+    format             = "${var.papertrail_log_format}"
+    response_condition = "response-phoenix-dev"
   }
 
   papertrail {
     name               = "rogue-dev"
     address            = "${element(split(":", var.papertrail_destination), 0)}"
     port               = "${element(split(":", var.papertrail_destination), 1)}"
-    format             = "%t '%r' status=%>s bytes=%b microseconds=%D"
-    response_condition = "errors-rogue-dev"
-  }
-
-  condition {
-    type      = "RESPONSE"
-    name      = "errors-graphql-dev"
-    statement = "req.http.host == \"${var.graphql_domain}\" && resp.status > 501 && resp.status < 600"
+    format             = "${var.papertrail_log_format}"
+    response_condition = "response-rogue-dev"
   }
 
   papertrail {
     name               = "graphql-dev"
     address            = "${element(split(":", var.papertrail_destination), 0)}"
     port               = "${element(split(":", var.papertrail_destination), 1)}"
-    format             = "%t '%r' status=%>s bytes=%b microseconds=%D"
-    response_condition = "errors-graphql-dev"
+    format             = "${var.papertrail_log_format}"
+    response_condition = "response-graphql-dev"
   }
 }

--- a/dosomething-dev/fastly-backend/main.tf
+++ b/dosomething-dev/fastly-backend/main.tf
@@ -13,7 +13,7 @@ variable "rogue_backend" {}
 variable "papertrail_destination" {}
 
 variable "papertrail_log_format" {
-  default = "%t '%r' status=%>s cache=%{X-Cache}o bytes=%b microseconds=%D"
+  default = "%t '%r' status=%>s cache=%{X-Cache}o country=%{X-Fastly-Country-Code}o bytes=%b microseconds=%D"
 }
 
 resource "fastly_service_v1" "backends-dev" {

--- a/dosomething-dev/fastly-backend/main.tf
+++ b/dosomething-dev/fastly-backend/main.tf
@@ -13,7 +13,7 @@ variable "rogue_backend" {}
 variable "papertrail_destination" {}
 
 variable "papertrail_log_format" {
-  default = "%t '%r' status=%>s bytes=%b microseconds=%D"
+  default = "%t '%r' status=%>s cache=%{X-Cache}o bytes=%b microseconds=%D"
 }
 
 resource "fastly_service_v1" "backends-dev" {

--- a/dosomething-qa/fastly-backend/main.tf
+++ b/dosomething-qa/fastly-backend/main.tf
@@ -66,6 +66,7 @@ resource "fastly_service_v1" "backends-qa" {
     address           = "${var.graphql_backend}"
     name              = "${var.graphql_name}"
     request_condition = "backend-graphql-qa"
+    shield            = "iad-va-us"
     auto_loadbalance  = false
     port              = 443
   }
@@ -74,6 +75,7 @@ resource "fastly_service_v1" "backends-qa" {
     address           = "${var.northstar_backend}"
     name              = "${var.northstar_name}"
     request_condition = "backend-northstar-qa"
+    shield            = "iad-va-us"
     auto_loadbalance  = false
     port              = 443
   }
@@ -82,6 +84,7 @@ resource "fastly_service_v1" "backends-qa" {
     address           = "${var.phoenix_backend}"
     name              = "${var.phoenix_name}"
     request_condition = "backend-phoenix-qa"
+    shield            = "iad-va-us"
     auto_loadbalance  = false
     port              = 443
   }
@@ -90,6 +93,7 @@ resource "fastly_service_v1" "backends-qa" {
     address           = "${var.rogue_backend}"
     name              = "${var.rogue_name}"
     request_condition = "backend-rogue-qa"
+    shield            = "iad-va-us"
     auto_loadbalance  = false
     port              = 443
   }

--- a/dosomething-qa/fastly-backend/main.tf
+++ b/dosomething-qa/fastly-backend/main.tf
@@ -13,7 +13,7 @@ variable "rogue_backend" {}
 variable "papertrail_destination" {}
 
 variable "papertrail_log_format" {
-  default = "%t '%r' status=%>s cache=%{X-Cache}o bytes=%b microseconds=%D"
+  default = "%t '%r' status=%>s cache=%{X-Cache}o country=%{X-Fastly-Country-Code}o bytes=%b microseconds=%D"
 }
 
 resource "fastly_service_v1" "backends-qa" {

--- a/dosomething-qa/fastly-backend/main.tf
+++ b/dosomething-qa/fastly-backend/main.tf
@@ -13,7 +13,7 @@ variable "rogue_backend" {}
 variable "papertrail_destination" {}
 
 variable "papertrail_log_format" {
-  default = "%t '%r' status=%>s bytes=%b microseconds=%D"
+  default = "%t '%r' status=%>s cache=%{X-Cache}o bytes=%b microseconds=%D"
 }
 
 resource "fastly_service_v1" "backends-qa" {

--- a/dosomething/fastly-backend/main.tf
+++ b/dosomething/fastly-backend/main.tf
@@ -79,7 +79,7 @@ resource "fastly_service_v1" "backends" {
   }
 
   condition {
-    type      = "RESPOSNE"
+    type      = "RESPONSE"
     name      = "response-rogue"
     statement = "req.http.host == \"${var.rogue_domain}\""
   }

--- a/shared/origin_name.vcl
+++ b/shared/origin_name.vcl
@@ -1,3 +1,6 @@
-# Mark which backend is serving the request on a response header.
+# Mark which backend is serving the request on a header. (Or forward
+# along the name of the backend if this is running on a shield node.)
 # This is handy for debugging & logged in Papertrail. <goo.gl/TWF4kz>
-set beresp.http.X-Origin-Name = regsub(beresp.backend.name, "^(.*)--", "");
+if (! beresp.http.X-Origin-Name) {
+  set beresp.http.X-Origin-Name = regsub(beresp.backend.name, "^(.*)--", "");
+}


### PR DESCRIPTION
We're trying to reduce load on Northstar by caching responses in Fastly, but ran into problems since responses are cached per-node by default (and so if we hit a different Fastly POP on the next request, it'll still be a `MISS`).

This pull request enables [shielding](
https://docs.fastly.com/guides/performance-tuning/shielding) for our backend properties so all requests are funneled through a single POP for maximized cache hits (and few downsides, since all our backend services are already located in the same US East region & so don't need global POPs).

References #31.