### PR TITLE
Add 'welcome-home' to Ashes campaign slugs.

### DIFF
--- a/dosomething-qa/fastly-frontend/ashes_init.vcl
+++ b/dosomething-qa/fastly-frontend/ashes_init.vcl
@@ -297,6 +297,7 @@ table ashes_campaigns {
   "visionary-volunteer": "true",
   "vote-or-shut": "true",
   "week-without-oil": "true",
+  "welcome-home": "true",
   "welcome-home-0": "true",
   "who-has-their-eye-you": "true",
   "whole-new-ball-game": "true",

--- a/dosomething/fastly-frontend/ashes_init.vcl
+++ b/dosomething/fastly-frontend/ashes_init.vcl
@@ -297,6 +297,7 @@ table ashes_campaigns {
   "visionary-volunteer": "true",
   "vote-or-shut": "true",
   "week-without-oil": "true",
+  "welcome-home": "true",
   "welcome-home-0": "true",
   "who-has-their-eye-you": "true",
   "whole-new-ball-game": "true",


### PR DESCRIPTION
This pull request routes the `welcome-home` slug to Ashes. References #33.