### PR TITLE
Trust proxies on Heroku.

### DIFF
--- a/longshot/application/main.tf
+++ b/longshot/application/main.tf
@@ -61,10 +61,11 @@ resource "heroku_app" "app" {
 
   config_vars {
     # App settings:
-    APP_ENV   = "production"
-    APP_DEBUG = "false"
-    APP_LOG   = "errorlog"
-    APP_URL   = "https://${var.host}"
+    APP_ENV                    = "production"
+    APP_DEBUG                  = "false"
+    APP_LOG                    = "errorlog"
+    APP_URL                    = "https://${var.host}"
+    TRUSTED_PROXY_IP_ADDRESSES = "**"
 
     # Drivers:
     QUEUE_DRIVER   = "sqs"


### PR DESCRIPTION
This pull request sets the `TRUSTED_PROXY_IP_ADDRESSES` environment variable in our Longshot application template, for the middleware added in DoSomething/longshot#918.