### PR TITLE
WIP: Add production Longshot instances to Terraform/Heroku.

### DIFF
--- a/longshot/main.tf
+++ b/longshot/main.tf
@@ -23,7 +23,7 @@ module "longshot-qa" {
   papertrail_destination = "${var.papertrail_qa_destination}"
 }
 
-module "longshot-footlocer-internal" {
+module "longshot-footlocker-internal" {
   source = "application"
 
   name           = "longshot-footlocker-internal"

--- a/longshot/main.tf
+++ b/longshot/main.tf
@@ -22,3 +22,20 @@ module "longshot-qa" {
 
   papertrail_destination = "${var.papertrail_qa_destination}"
 }
+
+module "longshot-footlocer-internal" {
+  source = "application"
+
+  name           = "longshot-footlocker-internal"
+  host           = "footlocker-internal.dosomething.org"
+  pipeline       = "${heroku_pipeline.longshot.id}"
+  pipeline_stage = "production"
+
+  email_name    = "Foot Locker Scholar Athletes"
+  email_address = "footlocker@tmiagency.org"
+
+  database_name = "footlocker_internal"
+  database_type = "db.t2.medium"
+
+  papertrail_destination = "${var.papertrail_prod_destination}"
+}


### PR DESCRIPTION
This pull request will add new production instances for Footlocker Internal, Footlocker, and H&R Block (using the same databases as their existing EC2 counterparts, but new Heroku/S3/SQS resources).