### PR TITLE
Move 'Treat Yo Friends' to Phoenix.

### DIFF
--- a/dosomething-qa/fastly-frontend/ashes_init.vcl
+++ b/dosomething-qa/fastly-frontend/ashes_init.vcl
@@ -282,7 +282,6 @@ table ashes_campaigns {
   "trash-or-treat": "true",
   "trash-scavenger-hunt": "true",
   "trash-stash": "true",
-  "treat-yo-friends": "true",
   "treats-troops": "true",
   "trick-or-treat-tp": "true",
   "turn-down-sexism": "true",

--- a/dosomething/fastly-frontend/ashes_init.vcl
+++ b/dosomething/fastly-frontend/ashes_init.vcl
@@ -282,7 +282,6 @@ table ashes_campaigns {
   "trash-or-treat": "true",
   "trash-scavenger-hunt": "true",
   "trash-stash": "true",
-  "treat-yo-friends": "true",
   "treats-troops": "true",
   "trick-or-treat-tp": "true",
   "turn-down-sexism": "true",


### PR DESCRIPTION
This pull request removes [Treat Yo Friends](https://www.dosomething.org/us/campaigns/treat-yo-friends) from the list of Ashes campaigns.

References [this Slack conversation](https://dosomething.slack.com/archives/C2BPA7M8F/p1543416333134900).