### PR TITLE
Add New Relic to Footlocker & H&R Block apps.

### DIFF
--- a/longshot/application/main.tf
+++ b/longshot/application/main.tf
@@ -152,8 +152,8 @@ resource "heroku_app" "app" {
     S3_BUCKET         = "${aws_s3_bucket.storage.id}"
 
     # New Relic:
+    NEW_RELIC_ENABLED  = "${var.with_newrelic ? "true" : "false"}"
     NEW_RELIC_APP_NAME = "${var.with_newrelic ? var.name : ""}"
-    NEW_RELIC_LOG      = "${var.with_newrelic ? "stdout" : ""}"
 
     # We can't use a ternary on an optional resource, hence this hack! https://git.io/fp2pg
     NEW_RELIC_LICENSE_KEY = "${join("", data.aws_ssm_parameter.newrelic_api_key.*.value)}"
@@ -205,15 +205,6 @@ resource "heroku_pipeline_coupling" "app" {
 resource "heroku_addon" "redis" {
   app  = "${heroku_app.app.name}"
   plan = "heroku-redis:${var.redis_type}"
-}
-
-# Attach New Relic addon if enabled for this app. This
-# installs the New Relic PHP agent, and we use environment
-# variables on the app to connect it to our org account.
-resource "heroku_addon" "newrelic" {
-  count = "${var.with_newrelic ? 1 : 0}"
-  app   = "${heroku_app.app.name}"
-  plan  = "newrelic:wayne"
 }
 
 resource "aws_db_instance" "database" {

--- a/longshot/application/main.tf
+++ b/longshot/application/main.tf
@@ -5,6 +5,9 @@
 #   - /{name}/rds/username
 #   - /{name}/rds/password
 #   - /mandrill/api-key
+#
+# And required if using New Relic:
+#   - /newrelic/api-key
 
 # Required variables:
 variable "environment" {
@@ -81,6 +84,11 @@ variable "database_size_gb" {
   default     = 100
 }
 
+variable "with_newrelic" {
+  description = "Should New Relic be configured for this app? Generally only used on prod."
+  default     = false
+}
+
 data "aws_ssm_parameter" "database_username" {
   name = "/${var.name}/rds/username"
 }
@@ -91,6 +99,11 @@ data "aws_ssm_parameter" "database_password" {
 
 data "aws_ssm_parameter" "mandrill_api_key" {
   name = "/mandrill/api-key"
+}
+
+data "aws_ssm_parameter" "newrelic_api_key" {
+  count = "${var.with_newrelic ? 1 : 0}"
+  name  = "/newrelic/api-key"
 }
 
 # ----------------------------------------------------
@@ -137,6 +150,13 @@ resource "heroku_app" "app" {
     SQS_DEFAULT_QUEUE = "${aws_sqs_queue.queue.id}"
     S3_REGION         = "${aws_s3_bucket.storage.region}"
     S3_BUCKET         = "${aws_s3_bucket.storage.id}"
+
+    # New Relic:
+    NEW_RELIC_APP_NAME = "${var.with_newrelic ? var.name : ""}"
+    NEW_RELIC_LOG      = "${var.with_newrelic ? "stdout" : ""}"
+
+    # We can't use a ternary on an optional resource, hence this hack! https://git.io/fp2pg
+    NEW_RELIC_LICENSE_KEY = "${join("", data.aws_ssm_parameter.newrelic_api_key.*.value)}"
 
     # Additional secrets, set manually:
     # APP_KEY = ...
@@ -185,6 +205,15 @@ resource "heroku_pipeline_coupling" "app" {
 resource "heroku_addon" "redis" {
   app  = "${heroku_app.app.name}"
   plan = "heroku-redis:${var.redis_type}"
+}
+
+# Attach New Relic addon if enabled for this app. This
+# installs the New Relic PHP agent, and we use environment
+# variables on the app to connect it to our org account.
+resource "heroku_addon" "newrelic" {
+  count = "${var.with_newrelic ? 1 : 0}"
+  app   = "${heroku_app.app.name}"
+  plan  = "newrelic:wayne"
 }
 
 resource "aws_db_instance" "database" {

--- a/longshot/application/main.tf
+++ b/longshot/application/main.tf
@@ -152,8 +152,9 @@ resource "heroku_app" "app" {
     S3_BUCKET         = "${aws_s3_bucket.storage.id}"
 
     # New Relic:
-    NEW_RELIC_ENABLED  = "${var.with_newrelic ? "true" : "false"}"
-    NEW_RELIC_APP_NAME = "${var.with_newrelic ? var.name : ""}"
+    NEW_RELIC_ENABLED   = "${var.with_newrelic ? "true" : "false"}"
+    NEW_RELIC_APP_NAME  = "${var.with_newrelic ? var.name : ""}"
+    NEW_RELIC_LOG_LEVEL = "error"
 
     # We can't use a ternary on an optional resource, hence this hack! https://git.io/fp2pg
     NEW_RELIC_LICENSE_KEY = "${join("", data.aws_ssm_parameter.newrelic_api_key.*.value)}"

--- a/longshot/main.tf
+++ b/longshot/main.tf
@@ -36,6 +36,7 @@ module "longshot-footlocker" {
   database_type = "db.t2.medium"
 
   papertrail_destination = "${var.papertrail_prod_destination}"
+  with_newrelic          = true
 }
 
 module "longshot-footlocker-internal" {

--- a/longshot/main.tf
+++ b/longshot/main.tf
@@ -68,4 +68,5 @@ module "hrblock" {
   database_type = "db.t2.medium"
 
   papertrail_destination = "${var.papertrail_prod_destination}"
+  with_newrelic          = true
 }


### PR DESCRIPTION
This pull request adds optional New Relic support to the Longshot application module. If the `with_newrelic` argument is set, a New Relic Heroku add-on & appropriate environment variables will be set for that application.

References #49.