### PR TITLE
Updating prod work_mem to 120MB.

### DIFF
--- a/quasar/main.tf
+++ b/quasar/main.tf
@@ -286,12 +286,12 @@ resource "aws_db_parameter_group" "quasar-prod" {
     value = "2000000"
   }
 
-  # Recommended by PGTuner tool: https://pgtune.leopard.in.ua/#/
+  # Updated to match Heroku Premium-5 config which we experienced
+  # as more performant when our data warehouse was hosted there.
   # Amount of RAM available for joins/sort queries per connection.
-  # Based on 60 connections.
   parameter {
     name  = "work_mem"
-    value = "17476"
+    value = "120000"
   }
 }
 


### PR DESCRIPTION
Looking into Heroku configs for similar instance size, `work_mem` was set to 120MB. Matching our RDS Prod instance of Quasar to use the same, up from ~18MB. This should allow us to handle substantially larger queries before hitting disk.