### PR TITLE
Route 'batch' path to Ashes for Solr re-indexing.

### DIFF
--- a/dosomething-dev/fastly-frontend/ashes_recv.vcl
+++ b/dosomething-dev/fastly-frontend/ashes_recv.vcl
@@ -18,7 +18,7 @@ else if (req.url.path ~ "(?i)^\/index\.php$") {
   # The '/index.php' file is used by some Ashes admin pages:
   set req.http.X-Fastly-Backend = "ashes";
 }
-else if (req.url.path ~ "(?i)\/((us|mx|br)\/)?(admin|image|openid\-connect|file|sites|profiles|misc|user|taxonomy|modules|search|system|themes|node|js)") {
+else if (req.url.path ~ "(?i)\/((us|mx|br)\/)?(admin|batch|image|openid\-connect|file|sites|profiles|misc|user|taxonomy|modules|search|system|themes|node|js)") {
   # Drupal built-in and third-party modules are served by Ashes:
   set req.http.X-Fastly-Backend = "ashes";
 }

--- a/dosomething-qa/fastly-frontend/ashes_recv.vcl
+++ b/dosomething-qa/fastly-frontend/ashes_recv.vcl
@@ -18,7 +18,7 @@ else if (req.url.path ~ "(?i)^\/index\.php$") {
   # The '/index.php' file is used by some Ashes admin pages:
   set req.http.X-Fastly-Backend = "ashes";
 }
-else if (req.url.path ~ "(?i)\/((us|mx|br)\/)?(admin|image|openid\-connect|file|sites|profiles|misc|user|taxonomy|modules|search|system|themes|node|js)") {
+else if (req.url.path ~ "(?i)\/((us|mx|br)\/)?(admin|batch|image|openid\-connect|file|sites|profiles|misc|user|taxonomy|modules|search|system|themes|node|js)") {
   # Drupal built-in and third-party modules are served by Ashes:
   set req.http.X-Fastly-Backend = "ashes";
 }

--- a/dosomething/fastly-frontend/ashes_recv.vcl
+++ b/dosomething/fastly-frontend/ashes_recv.vcl
@@ -18,7 +18,7 @@ else if (req.url.path ~ "(?i)^\/index\.php$") {
   # The '/index.php' file is used by some Ashes admin pages:
   set req.http.X-Fastly-Backend = "ashes";
 }
-else if (req.url.path ~ "(?i)\/((us|mx|br)\/)?(admin|image|openid\-connect|file|sites|profiles|misc|user|taxonomy|modules|search|system|themes|node|js)") {
+else if (req.url.path ~ "(?i)\/((us|mx|br)\/)?(admin|batch|image|openid\-connect|file|sites|profiles|misc|user|taxonomy|modules|search|system|themes|node|js)") {
   # Drupal built-in and third-party modules are served by Ashes:
   set req.http.X-Fastly-Backend = "ashes";
 }


### PR DESCRIPTION
This pull request routes `us/batch/` to Ashes [so we can re-index Solr](https://dosomething.slack.com/archives/C2BPA7M8F/p1544642232032700?thread_ts=1544039437.060400&cid=C2BPA7M8F).