### PR TITLE
Removed missing campaign: "Cool Carol Crew".

### DIFF
--- a/dosomething-qa/fastly-frontend/ashes_init.vcl
+++ b/dosomething-qa/fastly-frontend/ashes_init.vcl
@@ -55,7 +55,6 @@ table ashes_campaigns {
   "color-care": "true",
   "comics-rescue": "true",
   "context-clues": "true",
-  "cool-carol-crew": "true",
   "coping-discrimination": "true",
   "crash-text-dummy": "true",
   "craziest-thing-i-did-save-money": "true",

--- a/dosomething/fastly-frontend/ashes_init.vcl
+++ b/dosomething/fastly-frontend/ashes_init.vcl
@@ -55,7 +55,6 @@ table ashes_campaigns {
   "color-care": "true",
   "comics-rescue": "true",
   "context-clues": "true",
-  "cool-carol-crew": "true",
   "coping-discrimination": "true",
   "crash-text-dummy": "true",
   "craziest-thing-i-did-save-money": "true",


### PR DESCRIPTION
This campaign is supposed to be served from Phoenix, and was missing from the
last batch that was switched over from Ashes.