### PR TITLE
Route about pages to Phoenix by default (QA only).

### DIFF
--- a/dosomething-dev/fastly-frontend/ashes_init.vcl
+++ b/dosomething-dev/fastly-frontend/ashes_init.vcl
@@ -97,6 +97,6 @@ table phoenix_facts {
 
 # This is an array of "about" pages that should be routed to Phoenix. Fastly's
 # VCL supports dictionaries, but not arrays... hence an array of all "true"!
-table phoenix_about {
+table ashes_about {
   # ...
 }

--- a/dosomething-dev/fastly-frontend/ashes_init.vcl
+++ b/dosomething-dev/fastly-frontend/ashes_init.vcl
@@ -95,7 +95,7 @@ table phoenix_facts {
   # ...
 }
 
-# This is an array of "about" pages that should be routed to Phoenix. Fastly's
+# This is an array of "about" pages that should be routed to Ashes. Fastly's
 # VCL supports dictionaries, but not arrays... hence an array of all "true"!
 table ashes_about {
   # ...

--- a/dosomething-dev/fastly-frontend/ashes_recv.vcl
+++ b/dosomething-dev/fastly-frontend/ashes_recv.vcl
@@ -27,8 +27,8 @@ else if (req.url.path ~ "(?i)\/((us|mx|br)\/)?(fact|sobre|volunteer|voluntario|r
   set req.http.X-Fastly-Backend = "ashes";
 }
 else if (req.url.path ~ "(?i)\/((us|mx|br)\/)?about/([A-Za-z0-9_\-]+)" &&
-    ! table.lookup(phoenix_about, std.tolower(re.group.3))) {
-  # About pages default to Ashes, but we'll opt some paths to Phoenix.
+    table.lookup(phoenix_about, std.tolower(re.group.3))) {
+  # See if a given about page should be served by Ashes.
   set req.http.X-Fastly-Backend = "ashes";
 }
 else if (req.url.path ~ "(?i)\/((us|mx|br)\/)?facts/([A-Za-z0-9_\-]+)" &&

--- a/dosomething-dev/fastly-frontend/ashes_recv.vcl
+++ b/dosomething-dev/fastly-frontend/ashes_recv.vcl
@@ -27,7 +27,7 @@ else if (req.url.path ~ "(?i)\/((us|mx|br)\/)?(fact|sobre|volunteer|voluntario|r
   set req.http.X-Fastly-Backend = "ashes";
 }
 else if (req.url.path ~ "(?i)\/((us|mx|br)\/)?about/([A-Za-z0-9_\-]+)" &&
-    table.lookup(phoenix_about, std.tolower(re.group.3))) {
+    table.lookup(ashes_about, std.tolower(re.group.3))) {
   # See if a given about page should be served by Ashes.
   set req.http.X-Fastly-Backend = "ashes";
 }

--- a/dosomething-qa/fastly-frontend/ashes_init.vcl
+++ b/dosomething-qa/fastly-frontend/ashes_init.vcl
@@ -305,9 +305,9 @@ table phoenix_facts {
   # ...
 }
 
-# This is an array of "about" pages that should be routed to Phoenix. Fastly's
+# This is an array of "about" pages that should be routed to Ashes. Fastly's
 # VCL supports dictionaries, but not arrays... hence an array of all "true"!
-table phoenix_about {
-  "our-press": "true",
+table ashes_about {
+  "its-your-world": "true",
   # ...
 }

--- a/dosomething-qa/fastly-frontend/ashes_recv.vcl
+++ b/dosomething-qa/fastly-frontend/ashes_recv.vcl
@@ -27,8 +27,8 @@ else if (req.url.path ~ "(?i)\/((us|mx|br)\/)?(fact|sobre|volunteer|voluntario|r
   set req.http.X-Fastly-Backend = "ashes";
 }
 else if (req.url.path ~ "(?i)\/((us|mx|br)\/)?about/([A-Za-z0-9_\-]+)" &&
-    ! table.lookup(phoenix_about, std.tolower(re.group.3))) {
-  # About pages default to Ashes, but we'll opt some paths to Phoenix.
+    table.lookup(ashes_about, std.tolower(re.group.3))) {
+  # See if a given about page should be served by Ashes.
   set req.http.X-Fastly-Backend = "ashes";
 }
 else if (req.url.path ~ "(?i)\/((us|mx|br)\/)?facts/([A-Za-z0-9_\-]+)" &&


### PR DESCRIPTION
Updates the lookup table to hold exceptions for about pages that should be served from Ashes for QA. The majority of pages should be served from Phoenix now.