### PR TITLE
Add PASS cache setting to backend requests with auth token.

### DIFF
--- a/dosomething-dev/fastly-backend/main.tf
+++ b/dosomething-dev/fastly-backend/main.tf
@@ -96,10 +96,10 @@ resource "fastly_service_v1" "backends-dev" {
     statement = "req.http.Authorization"
   }
 
-  cache_setting {
-    name            = "pass-authenticated"
-    cache_condition = "is-authenticated"
-    action          = "pass"
+  request_setting {
+    name              = "pass-authenticated"
+    request_condition = "is-authenticated"
+    action            = "pass"
   }
 
   backend {

--- a/dosomething-dev/fastly-backend/main.tf
+++ b/dosomething-dev/fastly-backend/main.tf
@@ -90,6 +90,18 @@ resource "fastly_service_v1" "backends-dev" {
     statement = "req.url.basename == \"robots.txt\""
   }
 
+  condition {
+    type      = "CACHE"
+    name      = "is-authenticated"
+    statement = "req.http.authenticated"
+  }
+
+  cache_setting {
+    name            = "pass-authenticated"
+    cache_condition = "is-authenticated"
+    action          = "pass"
+  }
+
   backend {
     address           = "${var.graphql_backend}"
     name              = "${var.graphql_name}"

--- a/dosomething-dev/fastly-backend/main.tf
+++ b/dosomething-dev/fastly-backend/main.tf
@@ -93,7 +93,7 @@ resource "fastly_service_v1" "backends-dev" {
   condition {
     type      = "REQUEST"
     name      = "is-authenticated"
-    statement = "req.http.authorization"
+    statement = "req.http.Authorization"
   }
 
   cache_setting {

--- a/dosomething-dev/fastly-backend/main.tf
+++ b/dosomething-dev/fastly-backend/main.tf
@@ -93,7 +93,7 @@ resource "fastly_service_v1" "backends-dev" {
   condition {
     type      = "CACHE"
     name      = "is-authenticated"
-    statement = "req.http.authenticated"
+    statement = "req.http.authorization"
   }
 
   cache_setting {

--- a/dosomething-dev/fastly-backend/main.tf
+++ b/dosomething-dev/fastly-backend/main.tf
@@ -91,7 +91,7 @@ resource "fastly_service_v1" "backends-dev" {
   }
 
   condition {
-    type      = "CACHE"
+    type      = "REQUEST"
     name      = "is-authenticated"
     statement = "req.http.authorization"
   }

--- a/dosomething-qa/fastly-backend/main.tf
+++ b/dosomething-qa/fastly-backend/main.tf
@@ -72,7 +72,7 @@ resource "fastly_service_v1" "backends-qa" {
   }
 
   condition {
-    type      = "CACHE"
+    type      = "REQUEST"
     name      = "is-authenticated"
     statement = "req.http.authorization"
   }

--- a/dosomething-qa/fastly-backend/main.tf
+++ b/dosomething-qa/fastly-backend/main.tf
@@ -77,10 +77,10 @@ resource "fastly_service_v1" "backends-qa" {
     statement = "req.http.Authorization"
   }
 
-  cache_setting {
-    name            = "pass-authenticated"
-    cache_condition = "is-authenticated"
-    action          = "pass"
+  request_setting {
+    name              = "pass-authenticated"
+    request_condition = "is-authenticated"
+    action            = "pass"
   }
 
   backend {

--- a/dosomething-qa/fastly-backend/main.tf
+++ b/dosomething-qa/fastly-backend/main.tf
@@ -74,7 +74,7 @@ resource "fastly_service_v1" "backends-qa" {
   condition {
     type      = "CACHE"
     name      = "is-authenticated"
-    statement = "req.http.authenticated"
+    statement = "req.http.authorization"
   }
 
   cache_setting {

--- a/dosomething-qa/fastly-backend/main.tf
+++ b/dosomething-qa/fastly-backend/main.tf
@@ -71,6 +71,18 @@ resource "fastly_service_v1" "backends-qa" {
     statement = "req.url.basename == \"robots.txt\""
   }
 
+  condition {
+    type      = "CACHE"
+    name      = "is-authenticated"
+    statement = "req.http.authenticated"
+  }
+
+  cache_setting {
+    name            = "pass-authenticated"
+    cache_condition = "is-authenticated"
+    action          = "pass"
+  }
+
   backend {
     address           = "${var.graphql_backend}"
     name              = "${var.graphql_name}"

--- a/dosomething-qa/fastly-backend/main.tf
+++ b/dosomething-qa/fastly-backend/main.tf
@@ -74,7 +74,7 @@ resource "fastly_service_v1" "backends-qa" {
   condition {
     type      = "REQUEST"
     name      = "is-authenticated"
-    statement = "req.http.authorization"
+    statement = "req.http.Authorization"
   }
 
   cache_setting {

--- a/dosomething/fastly-backend/main.tf
+++ b/dosomething/fastly-backend/main.tf
@@ -96,6 +96,18 @@ resource "fastly_service_v1" "backends" {
     request_condition = "path-robots-preview"
   }
 
+  condition {
+    type      = "REQUEST"
+    name      = "is-authenticated"
+    statement = "req.http.Authorization"
+  }
+
+  request_setting {
+    name              = "pass-authenticated"
+    request_condition = "is-authenticated"
+    action            = "pass"
+  }
+
   backend {
     address           = "${var.graphql_backend}"
     name              = "${var.graphql_name}"


### PR DESCRIPTION
This should address an issue where we'd continue to serve cached content (e.g. public profiles where we'd set a `Cache-Control` header) to subsequent authenticated requests. Fixes #90.