### PR TITLE
Serve 'Explore Campaigns' from Phoenix on dev/QA.

### DIFF
--- a/dosomething-dev/fastly-frontend/ashes_recv.vcl
+++ b/dosomething-dev/fastly-frontend/ashes_recv.vcl
@@ -10,8 +10,8 @@ if (req.url.path ~ "(?i)^\/((us|mx|br)\/?)?$") {
   # The homepage & international variants are served by Ashes:
   set req.http.X-Fastly-Backend = "ashes";
 }
-else if (req.url.path ~ "(?i)^\/((us|mx|br)\/?)?campaigns\/?$") {
-  # The Explore Campaigns page is served by Ashes:
+else if (req.url.path ~ "(?i)^\/((mx|br)\/?)?campaigns\/?$") {
+  # The Mexican/Brazilian Explore Campaigns page is served by Ashes:
   set req.http.X-Fastly-Backend = "ashes";
 }
 else if (req.url.path ~ "(?i)^\/index\.php$") {

--- a/dosomething-qa/fastly-frontend/ashes_recv.vcl
+++ b/dosomething-qa/fastly-frontend/ashes_recv.vcl
@@ -10,8 +10,8 @@ if (req.url.path ~ "(?i)^\/((us|mx|br)\/?)?$") {
   # The homepage & international variants are served by Ashes:
   set req.http.X-Fastly-Backend = "ashes";
 }
-else if (req.url.path ~ "(?i)^\/((us|mx|br)\/?)?campaigns\/?$") {
-  # The Explore Campaigns page is served by Ashes:
+else if (req.url.path ~ "(?i)^\/((mx|br)\/?)?campaigns\/?$") {
+  # The Mexican/Brazilian Explore Campaigns page is served by Ashes:
   set req.http.X-Fastly-Backend = "ashes";
 }
 else if (req.url.path ~ "(?i)^\/index\.php$") {


### PR DESCRIPTION
We want to start testing the new [Explore Campaigns](https://github.com/DoSomething/phoenix-next/pull/1208) page with real data on QA. This pull request routes `/us/campaigns` to Phoenix, while continuing to route the Mexican & Brazilian equivalents to Ashes.