### PR TITLE
Serve US homepage from Phoenix on Development & QA.

### DIFF
--- a/dosomething-dev/fastly-frontend/ashes_recv.vcl
+++ b/dosomething-dev/fastly-frontend/ashes_recv.vcl
@@ -6,8 +6,8 @@
 unset req.http.X-Fastly-Backend;
 
 # Should this page be served by Ashes? Let's see:
-if (req.url.path ~ "(?i)^\/((us|mx|br)\/?)?$") {
-  # The homepage & international variants are served by Ashes:
+if (req.url.path ~ "(?i)^\/((mx|br)\/?)?$") {
+  # The international homepages are served by Ashes:
   set req.http.X-Fastly-Backend = "ashes";
 }
 else if (req.url.path ~ "(?i)^\/((mx|br)\/?)?campaigns\/?$") {

--- a/dosomething-qa/fastly-frontend/ashes_recv.vcl
+++ b/dosomething-qa/fastly-frontend/ashes_recv.vcl
@@ -6,8 +6,8 @@
 unset req.http.X-Fastly-Backend;
 
 # Should this page be served by Ashes? Let's see:
-if (req.url.path ~ "(?i)^\/((us|mx|br)\/?)?$") {
-  # The homepage & international variants are served by Ashes:
+if (req.url.path ~ "(?i)^\/((mx|br)\/?)?$") {
+  # The international homepages are served by Ashes:
   set req.http.X-Fastly-Backend = "ashes";
 }
 else if (req.url.path ~ "(?i)^\/((mx|br)\/?)?campaigns\/?$") {


### PR DESCRIPTION
This pull request updates our front-end routing rules to serve the homepage (`/` and `/us`) from Phoenix instead of Ashes. The Mexican & Brazilian homepages will continue to be served by Ashes.

References [this Slack conversation](https://dosomething.slack.com/archives/C3ASB4204/p1545081843047000), and [#162716731](https://www.pivotaltracker.com/story/show/162716731)