### PR TITLE
Add database, storage, queue, and IAM resources to apps.

### DIFF
--- a/applications/longshot/main.tf
+++ b/applications/longshot/main.tf
@@ -88,6 +88,7 @@ module "database" {
   source = "../../shared/mariadb_instance"
 
   name              = "${var.name}"
+  database_name     = "longshot"
   instance_class    = "${var.environment == "production" ? "db.t2.medium" : "db.t2.micro"}"
   allocated_storage = "${var.environment == "production" ? 100 : 5}"
 

--- a/applications/longshot/main.tf
+++ b/applications/longshot/main.tf
@@ -88,6 +88,7 @@ module "database" {
   source = "../../shared/mariadb_instance"
 
   name              = "${var.name}"
+  environmnet       = "${var.environment}"
   database_name     = "longshot"
   instance_class    = "${var.environment == "production" ? "db.t2.medium" : "db.t2.micro"}"
   allocated_storage = "${var.environment == "production" ? 100 : 5}"

--- a/applications/longshot/main.tf
+++ b/applications/longshot/main.tf
@@ -88,7 +88,7 @@ module "database" {
   source = "../../shared/mariadb_instance"
 
   name              = "${var.name}"
-  environmnet       = "${var.environment}"
+  environment       = "${var.environment}"
   database_name     = "longshot"
   instance_class    = "${var.environment == "production" ? "db.t2.medium" : "db.t2.micro"}"
   allocated_storage = "${var.environment == "production" ? 100 : 5}"

--- a/applications/longshot/main.tf
+++ b/applications/longshot/main.tf
@@ -90,6 +90,9 @@ module "database" {
   name              = "${var.name}"
   instance_class    = "${var.environment == "production" ? "db.t2.medium" : "db.t2.micro"}"
   allocated_storage = "${var.environment == "production" ? 100 : 5}"
+
+  subnet_group    = "default-vpc-7899331d"
+  security_groups = ["sg-c9a37db2"]
 }
 
 module "iam_user" {

--- a/applications/northstar/main.tf
+++ b/applications/northstar/main.tf
@@ -1,7 +1,26 @@
 # This template builds a Northstar application instance.
 #
-# Required SSM parameter if using New Relic:
-#   - /newrelic/api-key
+# Manual setup steps:
+#   - Configure a MongoDB Atlas database & set credentials in
+#     '/{name}/mongoatlas/host', '/{name}/mongoatlas/database',
+#     '/{name}/mongoatlas/username' & '/{name}/mongoatlas/password'.
+#   - Set 'FACEBOOK_APP_ID', 'FACEBOOK_APP_SECRET', and 'FACEBOOK_REDIRECT_URL'
+#     to the appropriate settings for this app from <developers.facebook.com>.
+#   - Set 'BLINK_URL', 'BLINK_USERNAME', and 'BLINK_PASSWORD' if using
+#     Blink, and set 'DS_ENABLE_BLINK' environment variable to 'true'.
+#   - Set 'APP_AUTH_KEY' by running `vendor/bin/generate-defuse-key`
+#     script from within this application, and 'APP_KEY' by running
+#     'php artisan generate:key'.
+#   - Finally, head to the S3 Bucket in AWS after provisioning, and go to the
+#     Permissions -> Public Access Settings screen. Check all the options.
+#
+# Required SSM parameters:
+#   - /{name}/mongoatlas/host
+#   - /{name}/mongoatlas/database
+#   - /{name}/mongoatlas/username
+#   - /{name}/mongoatlas/password
+#   - /mandrill/api-key
+#   - /newrelic/api-key (if using New Relic)
 
 # Required variables:
 variable "environment" {
@@ -30,7 +49,54 @@ variable "with_newrelic" {
   default     = ""
 }
 
-locals {}
+data "aws_ssm_parameter" "database_host" {
+  name = "/${var.name}/mongoatlas/host"
+}
+
+data "aws_ssm_parameter" "database_name" {
+  name = "/${var.name}/mongoatlas/database"
+}
+
+data "aws_ssm_parameter" "database_username" {
+  name = "/${var.name}/mongoatlas/username"
+}
+
+data "aws_ssm_parameter" "database_password" {
+  name = "/${var.name}/mongoatlas/password"
+}
+
+data "aws_ssm_parameter" "mandrill_api_key" {
+  name = "/mandrill/api-key"
+}
+
+locals {
+  database_config_vars = {
+    DB_HOST      = "${data.aws_ssm_parameter.database_host.value}"
+    DB_NAME      = "${data.aws_ssm_parameter.database_name.value}"
+    DB_USERNAME  = "${data.aws_ssm_parameter.database_username.value}"
+    DB_PASSWORD  = "${data.aws_ssm_parameter.database_password.value}"
+    DB_PORT      = 27017
+    DB_AUTH_NAME = "admin"
+    DB_SSL       = true
+  }
+
+  mail_config_vars = {
+    MAIL_DRIVER     = "mandrill"
+    MAIL_HOST       = "smtp.mandrillapp.com"
+    EMAIL_NAME      = "DoSomething.org"
+    EMAIL_ADDRESS   = "no-reply@dosomething.org"
+    MANDRILL_SECRET = "${data.aws_ssm_parameter.mandrill_api_key.value}"
+  }
+
+  queue_low_config_vars = {
+    SQS_LOW_PRIORITY_QUEUE = "${module.queue_low.arn}"
+  }
+
+  feature_config_vars = {
+    DS_ENABLE_PASSWORD_GRANT = false
+    DS_ENABLE_RATE_LIMITING  = true
+  }
+}
 
 module "app" {
   source = "../../shared/laravel_app"
@@ -39,6 +105,16 @@ module "app" {
   domain      = "${var.domain}"
   pipeline    = "${var.pipeline}"
   environment = "${var.environment}"
+
+  # TODO: Add 'module.queue_high.config_vars' once
+  # we're ready to swap to using new IAM config vars.
+  config_vars = "${merge(
+    module.storage.config_vars,
+    module.iam_user.config_vars,
+    local.queue_low_config_vars,
+    local.database_config_vars,
+    local.mail_config_vars
+  )}"
 
   # We use autoscaling in production, so don't try to manage dynos there.
   ignore_web = "${var.environment == "production"}"
@@ -51,6 +127,34 @@ module "app" {
 
   papertrail_destination = "${var.papertrail_destination}"
   with_newrelic          = "${coalesce(var.with_newrelic, var.environment == "production")}"
+}
+
+module "iam_user" {
+  source = "../../shared/iam_app_user"
+  name   = "${var.name}"
+}
+
+module "queue_high" {
+  source = "../../shared/sqs_queue"
+
+  name = "${var.name}-high"
+  user = "${module.iam_user.name}"
+}
+
+module "queue_low" {
+  source = "../../shared/sqs_queue"
+
+  name = "${var.name}-low"
+  user = "${module.iam_user.name}"
+}
+
+// TODO: Attach 'aws_s3_bucket_public_access_block' once this
+// is merged in to the AWS provider. <https://git.io/fpxqg>
+module "storage" {
+  source = "../../shared/s3_bucket"
+
+  name = "${var.name}"
+  user = "${module.iam_user.name}"
 }
 
 output "name" {

--- a/applications/northstar/main.tf
+++ b/applications/northstar/main.tf
@@ -85,7 +85,7 @@ locals {
   }
 
   queue_low_config_vars = {
-    SQS_LOW_PRIORITY_QUEUE = "${module.queue_low.arn}"
+    SQS_LOW_PRIORITY_QUEUE = "${module.queue_low.id}"
   }
 
   feature_config_vars = {

--- a/applications/northstar/main.tf
+++ b/applications/northstar/main.tf
@@ -1,6 +1,8 @@
 # This template builds a Northstar application instance.
 #
 # Manual setup steps:
+#   - Set '/mandrill/api-key' to the Mandrill API Key.
+#   - Set '/newrelic/api-key' to the New Relic API Key, if using.
 #   - Configure a MongoDB Atlas database & set credentials in
 #     '/{name}/mongoatlas/host', '/{name}/mongoatlas/database',
 #     '/{name}/mongoatlas/username' & '/{name}/mongoatlas/password'.
@@ -13,6 +15,8 @@
 #     'php artisan generate:key'.
 #   - Finally, head to the S3 Bucket in AWS after provisioning, and go to the
 #     Permissions -> Public Access Settings screen. Check all the options.
+#
+# NOTE: We'll move more of these steps into Terraform over time!
 #
 # Required SSM parameters:
 #   - /{name}/mongoatlas/host

--- a/applications/northstar/main.tf
+++ b/applications/northstar/main.tf
@@ -106,14 +106,16 @@ module "app" {
   pipeline    = "${var.pipeline}"
   environment = "${var.environment}"
 
+  # TODO: Add 'module.storage.config_vars' once we've migrated
+  # files over to the new storage buckets.
   # TODO: Add 'module.queue_high.config_vars' once
   # we're ready to swap to using new IAM config vars.
   config_vars = "${merge(
-    module.storage.config_vars,
     module.iam_user.config_vars,
-    local.queue_low_config_vars,
     local.database_config_vars,
-    local.mail_config_vars
+    local.feature_config_vars,
+    local.mail_config_vars,
+    local.queue_low_config_vars
   )}"
 
   # We use autoscaling in production, so don't try to manage dynos there.

--- a/applications/northstar/main.tf
+++ b/applications/northstar/main.tf
@@ -17,14 +17,6 @@
 #     Permissions -> Public Access Settings screen. Check all the options.
 #
 # NOTE: We'll move more of these steps into Terraform over time!
-#
-# Required SSM parameters:
-#   - /{name}/mongoatlas/host
-#   - /{name}/mongoatlas/database
-#   - /{name}/mongoatlas/username
-#   - /{name}/mongoatlas/password
-#   - /mandrill/api-key
-#   - /newrelic/api-key (if using New Relic)
 
 # Required variables:
 variable "environment" {

--- a/applications/northstar/main.tf
+++ b/applications/northstar/main.tf
@@ -161,6 +161,7 @@ module "storage" {
 
   name = "${var.name}"
   user = "${module.iam_user.name}"
+  acl  = "private"
 }
 
 output "name" {

--- a/applications/phoenix/main.tf
+++ b/applications/phoenix/main.tf
@@ -47,6 +47,8 @@ module "app" {
   pipeline    = "${var.pipeline}"
   environment = "${var.environment}"
 
+  config_vars = "${module.database.config_vars}"
+
   web_size = "${coalesce(var.web_size, var.environment == "production" ? "Performance-M" : "Hobby")}"
 
   queue_scale = 0
@@ -56,6 +58,13 @@ module "app" {
 
   papertrail_destination = "${var.papertrail_destination}"
   with_newrelic          = "${coalesce(var.with_newrelic, var.environment == "production")}"
+}
+
+module "database" {
+  source = "../../shared/mariadb_instance"
+
+  name           = "${var.name}"
+  instance_class = "${var.environment == "production" ? "db.t2.large" : "db.t2.micro"}"
 }
 
 output "name" {

--- a/applications/phoenix/main.tf
+++ b/applications/phoenix/main.tf
@@ -110,7 +110,7 @@ module "database" {
   source = "../../shared/mariadb_instance"
 
   name           = "${var.name}"
-  environmnet    = "${var.environment}"
+  environment    = "${var.environment}"
   instance_class = "${var.environment == "production" ? "db.t2.medium" : "db.t2.micro"}"
 }
 

--- a/applications/phoenix/main.tf
+++ b/applications/phoenix/main.tf
@@ -110,6 +110,7 @@ module "database" {
   source = "../../shared/mariadb_instance"
 
   name           = "${var.name}"
+  environmnet    = "${var.environment}"
   instance_class = "${var.environment == "production" ? "db.t2.medium" : "db.t2.micro"}"
 }
 

--- a/applications/phoenix/main.tf
+++ b/applications/phoenix/main.tf
@@ -1,12 +1,18 @@
 # This template builds a Phoenix application instance.
 #
-# Require SSM parameters for Contentful:
-#   - /contentful/phoenix/space-id
-#   - /{name}/contentful/content-api-key
-#   - /{name}/contentful/preview-api-key
+# Manual setup steps:
+#   - Create a Contentful API key for this application, and copy the generated values for both
+#     '/{name}/contentful/content-api-key' & '/{name}/contentful/preview-api-key' into SSM.
+#   - Set 'FACEBOOK_APP_ID', 'FACEBOOK_APP_SECRET', and 'FACEBOOK_REDIRECT_URL'
+#     to the appropriate settings for this app from <developers.facebook.com>.
+#   - Set 'APP_KEY' by running 'php artisan generate:key'.
+#   - Set 'BERTLY_API_KEY', 'BERTLY_URL', 'CUSTOMER_IO_ID', 'GOOGLE_ANALYTICS_ID',
+#     'GRAPHQL_URL', 'NORTHSTAR_AUTHORIZATION_ID', 'NORTHSTAR_AUTHORIZATION_SECRET',
+#     'NORTHSTAR_URL', 'NPS_SURVEY_ENABLED', 'PUCK_URL', 'ROGUE_URL', 'SIXPACK_BASE_URL',
+#     'SIXPACK_COOKIE_PREFIX', 'SIXPACK_ENABLED', and 'VOTER_REG_MODAL_ENABLED'.
+#   - Finally, set '/newrelic/api-key' in SSM to the New Relic API Key, if using.
 #
-# Required SSM parameter if using New Relic:
-#   - /newrelic/api-key
+# NOTE: We'll move more of these steps into Terraform over time!
 
 # Required variables:
 variable "environment" {

--- a/applications/phoenix/main.tf
+++ b/applications/phoenix/main.tf
@@ -110,7 +110,7 @@ module "database" {
   source = "../../shared/mariadb_instance"
 
   name           = "${var.name}"
-  instance_class = "${var.environment == "production" ? "db.t2.large" : "db.t2.micro"}"
+  instance_class = "${var.environment == "production" ? "db.t2.medium" : "db.t2.micro"}"
 }
 
 output "name" {

--- a/applications/phoenix/main.tf
+++ b/applications/phoenix/main.tf
@@ -59,7 +59,7 @@ data "aws_ssm_parameter" "contentful_space_id" {
 }
 
 data "aws_ssm_parameter" "contentful_api_key" {
-  # Grab the key for either Contentful's Content or Preview API, based on 'use_contentful_preview' setting.
+  # Grab the key for either Contentful's Content or Preview API, based on 'use_contentful_preview_api'.
   name = "/${var.name}/contentful/${var.use_contentful_preview_api ? "preview" : "content"}-api-key"
 }
 

--- a/applications/rogue/main.tf
+++ b/applications/rogue/main.tf
@@ -78,7 +78,7 @@ module "database" {
   source = "../../shared/mariadb_instance"
 
   name           = "${var.name}"
-  environmnet    = "${var.environment}"
+  environment    = "${var.environment}"
   instance_class = "${var.environment == "production" ? "db.m4.large" : "db.t2.medium"}"
   multi_az       = "${var.environment == "production"}"
 }

--- a/applications/rogue/main.tf
+++ b/applications/rogue/main.tf
@@ -79,6 +79,7 @@ module "database" {
 
   name           = "${var.name}"
   instance_class = "${var.environment == "production" ? "db.m4.large" : "db.t2.medium"}"
+  multi_az       = "${var.environment == "production"}"
 }
 
 module "iam_user" {

--- a/applications/rogue/main.tf
+++ b/applications/rogue/main.tf
@@ -43,11 +43,14 @@ module "app" {
   web_size  = "${var.environment == "production" ? "Standard-2x" : "Standard-1x"}"
   web_scale = "${var.environment == "production" ? 2 : 1}"
 
+  # TODO: Add 'module.database.config_vars' once we've migrated
+  # records over to the new database instance.
+  # TODO: Add 'module.storage.config_vars' once we've migrated
+  # files over to the new storage bucket.
+  # TODO: Add 'module.queue.config_vars' once we've updated this
+  # application to use the new IAM environment variables set below.
   config_vars = "${merge(
-    module.database.config_vars,
-    module.storage.config_vars,
     module.iam_user.config_vars,
-    module.queue.config_vars
   )}"
 
   # We don't run a queue process on development right now. @TODO: Should we?

--- a/applications/rogue/main.tf
+++ b/applications/rogue/main.tf
@@ -1,7 +1,19 @@
 # This template builds a Rogue application instance.
 #
-# Required SSM parameter if using New Relic:
-#   - /newrelic/api-key
+# Manual setup steps:
+#   - Set 'APP_KEY' by running 'php artisan generate:key'.
+#   - Set 'ROGUE_API_KEY' to a random string for this instance's v2 API key.
+#   - Create app-specific user & machine OAuth clients (via Aurora) and set the
+#     values for 'NORTHSTAR_URL', 'NORTHSTAR_AUTH_ID', 'NORTHSTAR_AUTH_SECRET',
+#      'NORTHSTAR_CLIENT_ID', and 'NORTHSTAR_CLIENT_SECRET'
+#   - Set 'BLINK_URL', 'BLINK_USERNAME', and 'BLINK_PASSWORD' if using
+#     Blink, and set 'DS_ENABLE_BLINK' environment variable to 'true'.
+#   - Set 'DS_ENABLE_BLINK', 'DS_ENABLE_GLIDE', 'DS_ENABLE_PUSH_TO_QUASAR',
+#     'DS_ENABLE_V3_QUANTITY_SUPPORT', 'FASTLY_API_TOKEN', 'FASTLY_SERVICE_ID',
+#     'FASTLY_URL', 'SLACK_ENDPOINT', and 'SLACK_WEBHOOK_INTEGRATION_URL'.
+#   - Finally, set '/newrelic/api-key' in SSM to the New Relic API Key, if using.
+#
+# NOTE: We'll move more of these steps into Terraform over time!
 
 # Required variables:
 variable "environment" {

--- a/applications/rogue/main.tf
+++ b/applications/rogue/main.tf
@@ -78,6 +78,7 @@ module "database" {
   source = "../../shared/mariadb_instance"
 
   name           = "${var.name}"
+  environmnet    = "${var.environment}"
   instance_class = "${var.environment == "production" ? "db.m4.large" : "db.t2.medium"}"
   multi_az       = "${var.environment == "production"}"
 }

--- a/dosomething/main.tf
+++ b/dosomething/main.tf
@@ -74,6 +74,8 @@ module "phoenix_preview" {
   web_size               = "Hobby"                         # TODO: Should this be Standard-1X?
   pipeline               = "${var.phoenix_pipeline}"
   papertrail_destination = "${var.papertrail_destination}"
+
+  use_contentful_preview_api = true
 }
 
 module "rogue" {

--- a/shared/mariadb_instance/main.tf
+++ b/shared/mariadb_instance/main.tf
@@ -62,9 +62,10 @@ resource "aws_iam_role" "rds_enhanced_monitoring" {
   assume_role_policy = "${data.aws_iam_policy_document.rds_enhanced_monitoring.json}"
 }
 
-resource "aws_iam_role_policy_attachment" "rds_enhanced_monitoring" {
-  role       = "${aws_iam_role.rds_enhanced_monitoring.name}"
-  policy_arn = "arn:aws:iam::aws:policy/service-role/AmazonRDSEnhancedMonitoringRole"
+resource "aws_iam_role_policy" "rds_enhanced_monitoring" {
+  name   = "${var.name}-monitoring-attachment"
+  role   = "${aws_iam_role.rds_enhanced_monitoring.name}"
+  policy = "${file("${path.module}/monitoring-policy.json")}"
 }
 
 data "aws_iam_policy_document" "rds_enhanced_monitoring" {

--- a/shared/mariadb_instance/main.tf
+++ b/shared/mariadb_instance/main.tf
@@ -24,6 +24,11 @@ variable "database_name" {
   default     = ""
 }
 
+variable "multi_az" {
+  description = "Should this instance be Multi-AZ for enhanced durability/availability? See: https://goo.gl/dqDazn"
+  default     = false
+}
+
 variable "subnet_group" {
   description = "The AWS subnet group name for this database."
   default     = "rds-mysql"
@@ -56,6 +61,7 @@ resource "aws_db_instance" "database" {
   engine_version    = "${var.engine_version}"
   instance_class    = "${var.instance_class}"
   allocated_storage = "${var.allocated_storage}"
+  multi_az          = "${var.multi_az}"
 
   allow_major_version_upgrade = true
 

--- a/shared/mariadb_instance/main.tf
+++ b/shared/mariadb_instance/main.tf
@@ -50,7 +50,7 @@ data "aws_ssm_parameter" "database_password" {
 
 resource "aws_db_instance" "database" {
   identifier = "${var.name}"
-  name       = "${coalesce(var.database_name, var.name)}"
+  name       = "${replace(coalesce(var.database_name, var.name), "-", "_")}"
 
   engine            = "mariadb"
   engine_version    = "${var.engine_version}"

--- a/shared/mariadb_instance/main.tf
+++ b/shared/mariadb_instance/main.tf
@@ -72,6 +72,10 @@ resource "aws_db_instance" "database" {
   backup_retention_period = "${var.environment == "production" ? 30 : 0}" # 30 days, or disabled.
   backup_window           = "06:00-07:00"                                 # 1-2am ET.
 
+  # Enable slow query log & enhanced monitoring. <https://goo.gl/xMx7GD>
+  enabled_cloudwatch_logs_exports = ["error", "slowquery"]
+  monitoring_interval             = 60
+
   username = "${data.aws_ssm_parameter.database_username.value}"
   password = "${data.aws_ssm_parameter.database_password.value}"
 

--- a/shared/mariadb_instance/main.tf
+++ b/shared/mariadb_instance/main.tf
@@ -20,12 +20,12 @@ variable "allocated_storage" {
 
 variable "subnet_group" {
   description = "The AWS subnet group name for this database."
-  default     = "default-vpc-7899331d"
+  default     = "rds-mysql"
 }
 
 variable "security_groups" {
   description = "The security group IDs for this database."
-  default     = ["sg-c9a37db2"]
+  default     = []
 }
 
 variable "deletion_protection" {

--- a/shared/mariadb_instance/main.tf
+++ b/shared/mariadb_instance/main.tf
@@ -31,7 +31,7 @@ variable "subnet_group" {
 
 variable "security_groups" {
   description = "The security group IDs for this database."
-  default     = []
+  default     = ["sg-0dca7669"]
 }
 
 variable "deletion_protection" {

--- a/shared/mariadb_instance/main.tf
+++ b/shared/mariadb_instance/main.tf
@@ -1,6 +1,6 @@
 # Required variables:
 variable "name" {
-  description = "The name for this database (usually the application name)."
+  description = "The identifier for the database instance (usually the application name)."
 }
 
 variable "instance_class" {
@@ -16,6 +16,12 @@ variable "engine_version" {
 variable "allocated_storage" {
   description = "The amount of storage to allocate to the database, in GB."
   default     = 100
+}
+
+variable "database_name" {
+  # See usage below for default value. <https://stackoverflow.com/a/51758050/811624>
+  description = "Optionally, the name for the database that should be provisioned at creation."
+  default     = ""
 }
 
 variable "subnet_group" {
@@ -44,7 +50,7 @@ data "aws_ssm_parameter" "database_password" {
 
 resource "aws_db_instance" "database" {
   identifier = "${var.name}"
-  name       = "longshot"
+  name       = "${coalesce(var.database_name, var.name)}"
 
   engine            = "mariadb"
   engine_version    = "${var.engine_version}"

--- a/shared/mariadb_instance/main.tf
+++ b/shared/mariadb_instance/main.tf
@@ -3,6 +3,10 @@ variable "name" {
   description = "The identifier for the database instance (usually the application name)."
 }
 
+variable "environment" {
+  description = "The environment for this database: development, qa, or production."
+}
+
 variable "instance_class" {
   description = "The RDS instance class. See: https://goo.gl/vTMqx9"
 }
@@ -65,8 +69,8 @@ resource "aws_db_instance" "database" {
 
   allow_major_version_upgrade = true
 
-  backup_retention_period = 7             # 7 days.
-  backup_window           = "06:00-07:00" # 1-2am ET.
+  backup_retention_period = "${var.environment == "production" ? 30 : 0}" # 30 days, or disabled.
+  backup_window           = "06:00-07:00"                                 # 1-2am ET.
 
   username = "${data.aws_ssm_parameter.database_username.value}"
   password = "${data.aws_ssm_parameter.database_password.value}"

--- a/shared/mariadb_instance/monitoring-policy.json
+++ b/shared/mariadb_instance/monitoring-policy.json
@@ -1,0 +1,29 @@
+{
+    "Version": "2012-10-17",
+    "Statement": [
+        {
+            "Sid": "EnableCreationAndManagementOfRDSCloudwatchLogGroups",
+            "Effect": "Allow",
+            "Action": [
+                "logs:CreateLogGroup",
+                "logs:PutRetentionPolicy"
+            ],
+            "Resource": [
+                "arn:aws:logs:*:*:log-group:RDS*"
+            ]
+        },
+        {
+            "Sid": "EnableCreationAndManagementOfRDSCloudwatchLogStreams",
+            "Effect": "Allow",
+            "Action": [
+                "logs:CreateLogStream",
+                "logs:PutLogEvents",
+                "logs:DescribeLogStreams",
+                "logs:GetLogEvents"
+            ],
+            "Resource": [
+                "arn:aws:logs:*:*:log-group:RDS*:log-stream:*"
+            ]
+        }
+    ]
+}

--- a/shared/mariadb_instance/monitoring-policy.json
+++ b/shared/mariadb_instance/monitoring-policy.json
@@ -1,29 +1,13 @@
 {
-    "Version": "2012-10-17",
-    "Statement": [
-        {
-            "Sid": "EnableCreationAndManagementOfRDSCloudwatchLogGroups",
-            "Effect": "Allow",
-            "Action": [
-                "logs:CreateLogGroup",
-                "logs:PutRetentionPolicy"
-            ],
-            "Resource": [
-                "arn:aws:logs:*:*:log-group:RDS*"
-            ]
-        },
-        {
-            "Sid": "EnableCreationAndManagementOfRDSCloudwatchLogStreams",
-            "Effect": "Allow",
-            "Action": [
-                "logs:CreateLogStream",
-                "logs:PutLogEvents",
-                "logs:DescribeLogStreams",
-                "logs:GetLogEvents"
-            ],
-            "Resource": [
-                "arn:aws:logs:*:*:log-group:RDS*:log-stream:*"
-            ]
-        }
-    ]
+  "Version": "2012-10-17",
+  "Statement": [
+    {
+      "Sid": "",
+      "Effect": "Allow",
+      "Principal": {
+        "Service": "monitoring.rds.amazonaws.com"
+      },
+      "Action": "sts:AssumeRole"
+    }
+  ]
 }

--- a/shared/s3_bucket/main.tf
+++ b/shared/s3_bucket/main.tf
@@ -7,9 +7,15 @@ variable "user" {
   description = "The IAM user to grant permissions to read/write to this bucket."
 }
 
+# Optional variables:
+variable "acl" {
+  description = "The canned ACL for this bucket. See: https://goo.gl/TFnRSY"
+  default     = "public-read"
+}
+
 resource "aws_s3_bucket" "bucket" {
   bucket = "${var.name}"
-  acl    = "public-read"
+  acl    = "${var.acl}"
 
   tags {
     Application = "${var.name}"


### PR DESCRIPTION
This pull request adds database, storage, queue, and IAM role resources to Northstar, Rogue, and Phoenix so we can manage and track these with Terraform. The game plan will be to provision the new resources (which use new, standardized environment variables & resource names) and we can swap to use them in production as we test each newly provisioned resource.

**Note:** None of this is applied, just pushing up my work before I'm OOO for the rest of the week!