### PR TITLE
Use newly provisioned resources for Northstar, Phoenix & Rogue.

### DIFF
--- a/applications/northstar/main.tf
+++ b/applications/northstar/main.tf
@@ -88,15 +88,6 @@ locals {
     SQS_LOW_PRIORITY_QUEUE = "${module.queue_low.id}"
   }
 
-  # TODO: Remove these once application is updated to use new vars.
-  legacy_config_vars = {
-    SQS_BACKFILL_QUEUE = "${module.queue_low.id}"
-    S3_KEY             = "${module.iam_user.config_vars["AWS_ACCESS_KEY"]}"
-    S3_SECRET          = "${module.iam_user.config_vars["AWS_SECRET_KEY"]}"
-    SQS_PUBLIC_KEY     = "${module.iam_user.config_vars["AWS_ACCESS_KEY"]}"
-    SQS_SECRET_KEY     = "${module.iam_user.config_vars["AWS_SECRET_KEY"]}"
-  }
-
   feature_config_vars = {
     DS_ENABLE_PASSWORD_GRANT = false
     DS_ENABLE_RATE_LIMITING  = true
@@ -115,11 +106,10 @@ module "app" {
     module.iam_user.config_vars,
     module.storage.config_vars,
     module.queue_high.config_vars,
+    local.queue_low_config_vars,
     local.database_config_vars,
     local.feature_config_vars,
-    local.mail_config_vars,
-    local.queue_low_config_vars,
-    local.legacy_config_vars
+    local.mail_config_vars
   )}"
 
   # We use autoscaling in production, so don't try to manage dynos there.

--- a/applications/northstar/main.tf
+++ b/applications/northstar/main.tf
@@ -88,6 +88,15 @@ locals {
     SQS_LOW_PRIORITY_QUEUE = "${module.queue_low.id}"
   }
 
+  # TODO: Remove these once application is updated to use new vars.
+  legacy_config_vars = {
+    SQS_BACKFILL_QUEUE = "${module.queue_low.id}"
+    S3_KEY             = "${module.iam_user.config_vars["AWS_ACCESS_KEY"]}"
+    S3_SECRET          = "${module.iam_user.config_vars["AWS_SECRET_KEY"]}"
+    SQS_PUBLIC_KEY     = "${module.iam_user.config_vars["AWS_ACCESS_KEY"]}"
+    SQS_SECRET_KEY     = "${module.iam_user.config_vars["AWS_SECRET_KEY"]}"
+  }
+
   feature_config_vars = {
     DS_ENABLE_PASSWORD_GRANT = false
     DS_ENABLE_RATE_LIMITING  = true
@@ -102,16 +111,15 @@ module "app" {
   pipeline    = "${var.pipeline}"
   environment = "${var.environment}"
 
-  # TODO: Add 'module.storage.config_vars' once we've migrated
-  # files over to the new storage buckets.
-  # TODO: Add 'module.queue_high.config_vars' once
-  # we're ready to swap to using new IAM config vars.
   config_vars = "${merge(
     module.iam_user.config_vars,
+    module.storage.config_vars,
+    module.queue_high.config_vars,
     local.database_config_vars,
     local.feature_config_vars,
     local.mail_config_vars,
-    local.queue_low_config_vars
+    local.queue_low_config_vars,
+    local.legacy_config_vars
   )}"
 
   # We use autoscaling in production, so don't try to manage dynos there.

--- a/applications/phoenix/main.tf
+++ b/applications/phoenix/main.tf
@@ -89,9 +89,8 @@ module "app" {
   pipeline    = "${var.pipeline}"
   environment = "${var.environment}"
 
-  # TODO: Add 'module.database.config_vars' once we've migrated
-  # records over to the new database instance.
   config_vars = "${merge(
+    module.database.config_vars,
     local.contentful_config_vars
   )}"
 

--- a/applications/rogue/main.tf
+++ b/applications/rogue/main.tf
@@ -98,6 +98,8 @@ module "storage" {
   source = "../../shared/s3_bucket"
   name   = "${var.name}"
   user   = "${module.iam_user.name}"
+
+  force_public = true
 }
 
 output "name" {

--- a/applications/rogue/main.tf
+++ b/applications/rogue/main.tf
@@ -99,6 +99,8 @@ module "storage" {
   name   = "${var.name}"
   user   = "${module.iam_user.name}"
 
+  # TODO: We should remove anywhere we depend on this behavior,
+  # such as Rogue's admin inbox, and then disable this.
   force_public = true
 }
 

--- a/applications/rogue/main.tf
+++ b/applications/rogue/main.tf
@@ -42,7 +42,15 @@ variable "with_newrelic" {
   default     = ""
 }
 
-locals {}
+locals {
+  # TODO: Remove these once application is updated to use new vars.
+  legacy_config_vars = {
+    S3_KEY         = "${module.iam_user.config_vars["AWS_ACCESS_KEY"]}"
+    S3_SECRET      = "${module.iam_user.config_vars["AWS_SECRET_KEY"]}"
+    SQS_PUBLIC_KEY = "${module.iam_user.config_vars["AWS_ACCESS_KEY"]}"
+    SQS_SECRET_KEY = "${module.iam_user.config_vars["AWS_SECRET_KEY"]}"
+  }
+}
 
 module "app" {
   source = "../../shared/laravel_app"
@@ -57,12 +65,11 @@ module "app" {
 
   # TODO: Add 'module.database.config_vars' once we've migrated
   # records over to the new database instance.
-  # TODO: Add 'module.storage.config_vars' once we've migrated
-  # files over to the new storage bucket.
-  # TODO: Add 'module.queue.config_vars' once we've updated this
-  # application to use the new IAM environment variables set below.
   config_vars = "${merge(
+    module.queue.config_vars,
     module.iam_user.config_vars,
+    module.storage.config_vars,
+    local.legacy_config_vars,
   )}"
 
   # We don't run a queue process on development right now. @TODO: Should we?

--- a/shared/mariadb_instance/main.tf
+++ b/shared/mariadb_instance/main.tf
@@ -40,7 +40,10 @@ variable "subnet_group" {
 
 variable "security_groups" {
   description = "The security group IDs for this database."
-  default     = ["sg-0dca7669"]
+
+  # TODO: Either update default security group to work here, or import
+  # this as part of a "environment" module in Terraform 0.12.
+  default = ["sg-a37efac7"]
 }
 
 variable "deletion_protection" {

--- a/shared/s3_bucket/main.tf
+++ b/shared/s3_bucket/main.tf
@@ -13,6 +13,11 @@ variable "acl" {
   default     = "public-read"
 }
 
+variable "force_public" {
+  description = "Force 'public read' permissions for objects. Not recommended."
+  default     = false
+}
+
 resource "aws_s3_bucket" "bucket" {
   bucket = "${var.name}"
   acl    = "${var.acl}"
@@ -23,7 +28,7 @@ resource "aws_s3_bucket" "bucket" {
 }
 
 data "template_file" "s3_policy" {
-  template = "${file("${path.module}/iam-policy.json.tpl")}"
+  template = "${file("${path.module}/${var.force_public ? "public-" : ""}iam-policy.json.tpl")}"
 
   vars {
     bucket_arn = "${aws_s3_bucket.bucket.arn}"

--- a/shared/s3_bucket/main.tf
+++ b/shared/s3_bucket/main.tf
@@ -28,7 +28,22 @@ resource "aws_s3_bucket" "bucket" {
 }
 
 data "template_file" "s3_policy" {
-  template = "${file("${path.module}/${var.force_public ? "public-" : ""}iam-policy.json.tpl")}"
+  template = "${file("${path.module}/iam-policy.json.tpl")}"
+
+  vars {
+    bucket_arn = "${aws_s3_bucket.bucket.arn}"
+  }
+}
+
+resource "aws_s3_bucket_policy" "bucket_policy" {
+  count = "${var.force_public ? 1 : 0}"
+
+  bucket = "${aws_s3_bucket.bucket.id}"
+  policy = "${data.template_file.public_bucket_policy.rendered}"
+}
+
+data "template_file" "public_bucket_policy" {
+  template = "${file("${path.module}/public-bucket-policy.json.tpl")}"
 
   vars {
     bucket_arn = "${aws_s3_bucket.bucket.arn}"

--- a/shared/s3_bucket/public-bucket-policy.json.tpl
+++ b/shared/s3_bucket/public-bucket-policy.json.tpl
@@ -2,17 +2,6 @@
     "Version": "2012-10-17",
     "Statement": [
         {
-            "Sid": "VisualEditor0",
-            "Effect": "Allow",
-            "Action": [
-                "s3:*"
-            ],
-            "Resource": [
-                "${bucket_arn}/*",
-                "${bucket_arn}"
-            ]
-        },
-        {
             "Sid": "PublicReadGetObject",
             "Effect": "Allow",
             "Principal": "*",

--- a/shared/s3_bucket/public-iam-policy.json.tpl
+++ b/shared/s3_bucket/public-iam-policy.json.tpl
@@ -1,0 +1,23 @@
+{
+    "Version": "2012-10-17",
+    "Statement": [
+        {
+            "Sid": "VisualEditor0",
+            "Effect": "Allow",
+            "Action": [
+                "s3:*"
+            ],
+            "Resource": [
+                "${bucket_arn}/*",
+                "${bucket_arn}"
+            ]
+        },
+        {
+            "Sid": "PublicReadGetObject",
+            "Effect": "Allow",
+            "Principal": "*",
+            "Action": "s3:GetObject",
+            "Resource": "${bucket_arn}/*"
+        }
+    ]
+}


### PR DESCRIPTION
This pull request continues the work started in #96 by swapping the applications to actually start using each newly provisioned resource (once we've copied over any necessary data).

In a shocking twist, Terraform [doesn't yet support maps in ternaries](https://git.io/fhYr7) (or any other sort of conditional) and so there's no easy way to only apply these changes to dev & QA environments via Terraform. Jeez! Since the resources already exist, I'm going to use the results of the plan to manually test each of the config changes on QA before applying across the board.