### PR TITLE
Use new Rogue RDS instances.

### DIFF
--- a/applications/rogue/main.tf
+++ b/applications/rogue/main.tf
@@ -63,9 +63,8 @@ module "app" {
   web_size  = "${var.environment == "production" ? "Standard-2x" : "Standard-1x"}"
   web_scale = "${var.environment == "production" ? 2 : 1}"
 
-  # TODO: Add 'module.database.config_vars' once we've migrated
-  # records over to the new database instance.
   config_vars = "${merge(
+    module.database.config_vars,
     module.queue.config_vars,
     module.iam_user.config_vars,
     module.storage.config_vars,


### PR DESCRIPTION
This pull request swaps Rogue to use the newly provisioned database instances. This is pending a little more work on getting a smooth database migration with DMS & ensuring that Quasar replication continues to work without a hitch.