### PR TITLE
Update legacy SQS config vars.

### DIFF
--- a/applications/rogue/main.tf
+++ b/applications/rogue/main.tf
@@ -45,10 +45,10 @@ variable "with_newrelic" {
 locals {
   # TODO: Remove these once application is updated to use new vars.
   legacy_config_vars = {
-    S3_KEY         = "${module.iam_user.config_vars["AWS_ACCESS_KEY"]}"
-    S3_SECRET      = "${module.iam_user.config_vars["AWS_SECRET_KEY"]}"
-    SQS_PUBLIC_KEY = "${module.iam_user.config_vars["AWS_ACCESS_KEY"]}"
-    SQS_SECRET_KEY = "${module.iam_user.config_vars["AWS_SECRET_KEY"]}"
+    S3_KEY                = "${module.iam_user.config_vars["AWS_ACCESS_KEY"]}"
+    S3_SECRET             = "${module.iam_user.config_vars["AWS_SECRET_KEY"]}"
+    SQS_ACCESS_KEY_ID     = "${module.iam_user.config_vars["AWS_ACCESS_KEY"]}"
+    SQS_SECRET_ACCESS_KEY = "${module.iam_user.config_vars["AWS_SECRET_KEY"]}"
   }
 }
 


### PR DESCRIPTION
I'd accidentally set the wrong "legacy" SQS environment variables for Rogue in #99, so we've been continuing to use the same old IAM role for SQS (although with the new queue). This pull request updates these to be [what Rogue currently uses](https://github.com/DoSomething/rogue/blob/e767fe012d7318c44716e0fda37e6faafa7929db/config/queue.php#L51-L58) so we can safely delete these old IAM users.