### PR TITLE
Set parameters for Rogue DMS replication.

### DIFF
--- a/applications/rogue/main.tf
+++ b/applications/rogue/main.tf
@@ -87,6 +87,7 @@ module "database" {
   environment    = "${var.environment}"
   instance_class = "${var.environment == "production" ? "db.m4.large" : "db.t2.medium"}"
   multi_az       = "${var.environment == "production"}"
+  is_dms_source  = true
 }
 
 module "iam_user" {


### PR DESCRIPTION
This pull request sets the [appropriate parameters & settings](https://goo.gl/yjNZ9u) for Rogue's new database instances so we can use them as sources for DMS replication into Quasar, via an optional `is_dms_source` flag.

References #100.