### PR TITLE
Add application database user.

### DIFF
--- a/shared/mariadb_instance/main.tf
+++ b/shared/mariadb_instance/main.tf
@@ -151,7 +151,7 @@ resource "mysql_user" "app" {
   count              = "${var.deprecated ? 0 : 1}"
   user               = "${local.safe_name}"
   host               = "%"
-  plaintext_password = "${random_string.readonly_password.result}"
+  plaintext_password = "${random_string.app_password.result}"
 }
 
 resource "mysql_grant" "app" {

--- a/shared/mariadb_instance/main.tf
+++ b/shared/mariadb_instance/main.tf
@@ -155,11 +155,13 @@ resource "mysql_user" "app" {
 }
 
 resource "mysql_grant" "app" {
-  count      = "${var.deprecated ? 0 : 1}"
-  user       = "${mysql_user.app.user}"
-  host       = "${mysql_user.app.host}"
-  database   = "${aws_db_instance.database.name}"
-  privileges = ["ALL"]
+  count    = "${var.deprecated ? 0 : 1}"
+  user     = "${mysql_user.app.user}"
+  host     = "${mysql_user.app.host}"
+  database = "${aws_db_instance.database.name}"
+
+  # Grant minimum privileges necessary for table usage & running migrations.
+  privileges = ["ALTER", "CREATE", "DELETE", "DROP", "INDEX", "INSERT", "SELECT", "UPDATE"]
 }
 
 resource "random_string" "readonly_password" {

--- a/shared/mariadb_instance/main.tf
+++ b/shared/mariadb_instance/main.tf
@@ -199,11 +199,11 @@ output "name" {
 }
 
 output "username" {
-  value = "${data.aws_ssm_parameter.database_username.value}"
+  value = "${join("", mysql_user.app.*.user)}"
 }
 
 output "password" {
-  value = "${data.aws_ssm_parameter.database_password.value}"
+  value = "${random_string.app_password.result}"
 }
 
 output "config_vars" {
@@ -211,7 +211,7 @@ output "config_vars" {
     DB_HOST     = "${aws_db_instance.database.address}"
     DB_PORT     = "${aws_db_instance.database.port}"
     DB_DATABASE = "${aws_db_instance.database.name}"
-    DB_USERNAME = "${data.aws_ssm_parameter.database_username.value}"
-    DB_PASSWORD = "${data.aws_ssm_parameter.database_password.value}"
+    DB_USERNAME = "${join("", mysql_user.app.*.user)}"
+    DB_PASSWORD = "${random_string.app_password.result}"
   }
 }


### PR DESCRIPTION
This pull request adds application users to each of our MariaDB databases, so that applications don't have [full "root" access](https://docs.aws.amazon.com/AmazonRDS/latest/UserGuide/UsingWithRDS.MasterAccounts.html) to the RDS instance (say to add/remove other users or set up replication).

After provisioning these new limited users, I'll test them out on a few dev & QA instances before setting them in the module's outputs so they take effect across the board.