### PR TITLE
Enable versioning & backup replication on S3 buckets.

### DIFF
--- a/applications/northstar/main.tf
+++ b/applications/northstar/main.tf
@@ -149,9 +149,10 @@ module "queue_low" {
 module "storage" {
   source = "../../shared/s3_bucket"
 
-  name = "${var.name}"
-  user = "${module.iam_user.name}"
-  acl  = "private"
+  name       = "${var.name}"
+  user       = "${module.iam_user.name}"
+  acl        = "private"
+  versioning = true
 }
 
 output "name" {

--- a/applications/rogue/main.tf
+++ b/applications/rogue/main.tf
@@ -102,9 +102,10 @@ module "queue" {
 }
 
 module "storage" {
-  source = "../../shared/s3_bucket"
-  name   = "${var.name}"
-  user   = "${module.iam_user.name}"
+  source      = "../../shared/s3_bucket"
+  name        = "${var.name}"
+  user        = "${module.iam_user.name}"
+  replication = "${var.environment == "production"}"
 
   # TODO: We should remove anywhere we depend on this behavior,
   # such as Rogue's admin inbox, and then disable this.

--- a/main.tf
+++ b/main.tf
@@ -65,6 +65,13 @@ provider "aws" {
   profile = "terraform"
 }
 
+# In some cases, like backup buckets, we store resources
+# in Amazon's US West region.
+provider "aws" {
+  alias  = "west"
+  region = "us-west-1"
+}
+
 # The template provider is used to generate files with
 # interpolated variables (like JSON or VCL).
 provider "template" {

--- a/main.tf
+++ b/main.tf
@@ -68,8 +68,9 @@ provider "aws" {
 # In some cases, like backup buckets, we store resources
 # in Amazon's US West region.
 provider "aws" {
-  alias  = "west"
-  region = "us-west-1"
+  alias   = "west"
+  region  = "us-west-1"
+  profile = "terraform"
 }
 
 # The template provider is used to generate files with

--- a/shared/s3_bucket/main.tf
+++ b/shared/s3_bucket/main.tf
@@ -13,6 +13,11 @@ variable "acl" {
   default     = "public-read"
 }
 
+variable "versioning" {
+  description = "Enable versioning on this bucket. See: https://goo.gl/idPRVV"
+  default     = false
+}
+
 variable "force_public" {
   description = "Force 'public read' permissions for objects. Not recommended."
   default     = false
@@ -21,6 +26,10 @@ variable "force_public" {
 resource "aws_s3_bucket" "bucket" {
   bucket = "${var.name}"
   acl    = "${var.acl}"
+
+  versioning {
+    enabled = "${var.versioning}"
+  }
 
   tags {
     Application = "${var.name}"

--- a/shared/s3_bucket/main.tf
+++ b/shared/s3_bucket/main.tf
@@ -120,7 +120,9 @@ resource "random_id" "lifecycle_rules" {
 }
 
 resource "aws_s3_bucket" "backup" {
-  count  = "${var.replication ? 1 : 0}"
+  provider = "aws.west"
+  count    = "${var.replication ? 1 : 0}"
+
   bucket = "${var.name}-backup"
   region = "us-west-1"
 

--- a/shared/s3_bucket/main.tf
+++ b/shared/s3_bucket/main.tf
@@ -18,12 +18,25 @@ variable "versioning" {
   default     = false
 }
 
+variable "replication" {
+  description = "Enable cross-region replication on this bucket. See: https://goo.gl/zt3QNn"
+  default     = false
+}
+
 variable "force_public" {
   description = "Force 'public read' permissions for objects. Not recommended."
   default     = false
 }
 
+locals {
+  bucket_id     = "${var.replication ? join("", aws_s3_bucket.replicated_bucket.*.id) : join("", aws_s3_bucket.bucket.*.id)}"
+  bucket_region = "${var.replication ? join("", aws_s3_bucket.replicated_bucket.*.region) : join("", aws_s3_bucket.bucket.*.region)}"
+  bucket_arn    = "${var.replication ? join("", aws_s3_bucket.replicated_bucket.*.arn) : join("", aws_s3_bucket.bucket.*.arn)}"
+}
+
+# Without 'replication' enabled:
 resource "aws_s3_bucket" "bucket" {
+  count  = "${var.replication ? 0 : 1}"
   bucket = "${var.name}"
   acl    = "${var.acl}"
 
@@ -36,18 +49,54 @@ resource "aws_s3_bucket" "bucket" {
   }
 }
 
+# With 'replication' enabled:
+resource "random_id" "replication_rules" {
+  count       = "${var.replication ? 1 : 0}"
+  byte_length = 32
+}
+
+# TODO: In Terraform 0.12, these two s3_bucket resources can
+# be combined with dynamic blocks! https://git.io/fhlmD
+resource "aws_s3_bucket" "replicated_bucket" {
+  count  = "${var.replication ? 1 : 0}"
+  bucket = "${var.name}"
+  acl    = "${var.acl}"
+
+  versioning {
+    enabled = true # Versioning must be enabled for replication to work.
+  }
+
+  replication_configuration {
+    role = "${aws_iam_role.replication.arn}"
+
+    rules {
+      id     = "${random_id.replication_rules.b64_std}"
+      status = "Enabled"
+
+      destination {
+        bucket        = "${aws_s3_bucket.backup.arn}"
+        storage_class = "STANDARD_IA"
+      }
+    }
+  }
+
+  tags {
+    Application = "${var.name}"
+  }
+}
+
 data "template_file" "s3_policy" {
   template = "${file("${path.module}/iam-policy.json.tpl")}"
 
   vars {
-    bucket_arn = "${aws_s3_bucket.bucket.arn}"
+    bucket_arn = "${local.bucket_arn}"
   }
 }
 
 resource "aws_s3_bucket_policy" "bucket_policy" {
   count = "${var.force_public ? 1 : 0}"
 
-  bucket = "${aws_s3_bucket.bucket.id}"
+  bucket = "${local.bucket_id}"
   policy = "${data.template_file.public_bucket_policy.rendered}"
 }
 
@@ -55,7 +104,7 @@ data "template_file" "public_bucket_policy" {
   template = "${file("${path.module}/public-bucket-policy.json.tpl")}"
 
   vars {
-    bucket_arn = "${aws_s3_bucket.bucket.arn}"
+    bucket_arn = "${local.bucket_arn}"
   }
 }
 
@@ -65,18 +114,74 @@ resource "aws_iam_user_policy" "s3_policy" {
   policy = "${data.template_file.s3_policy.rendered}"
 }
 
+resource "random_id" "lifecycle_rules" {
+  count       = "${var.replication ? 1 : 0}"
+  byte_length = 32
+}
+
+resource "aws_s3_bucket" "backup" {
+  count  = "${var.replication ? 1 : 0}"
+  bucket = "${var.name}-backup"
+  region = "us-west-1"
+
+  versioning {
+    enabled = true
+  }
+
+  lifecycle_rule {
+    id      = "${random_id.lifecycle_rules.b64_std}"
+    enabled = true
+
+    # Since we can't replicate directly into Glacier, set a lifecycle
+    # rule to move these backups there after 30 days.
+    transition {
+      days          = 30
+      storage_class = "GLACIER"
+    }
+  }
+}
+
+resource "aws_iam_role" "replication" {
+  count              = "${var.replication ? 1 : 0}"
+  name               = "${var.name}-s3-replication"
+  assume_role_policy = "${file("${path.module}/replication-role.json")}"
+}
+
+data "template_file" "replication_policy" {
+  count    = "${var.replication ? 1 : 0}"
+  template = "${file("${path.module}/replication-policy.json.tpl")}"
+
+  vars {
+    source_bucket_arn      = "${aws_s3_bucket.replicated_bucket.arn}"
+    destination_bucket_arn = "${aws_s3_bucket.backup.arn}"
+  }
+}
+
+resource "aws_iam_policy" "replication" {
+  count  = "${var.replication ? 1 : 0}"
+  name   = "${var.name}-replication-policy"
+  policy = "${data.template_file.replication_policy.rendered}"
+}
+
+resource "aws_iam_policy_attachment" "replication" {
+  count      = "${var.replication ? 1 : 0}"
+  name       = "${var.name}-replication-role-attachment"
+  roles      = ["${aws_iam_role.replication.name}"]
+  policy_arn = "${aws_iam_policy.replication.arn}"
+}
+
 output "id" {
-  value = "${aws_s3_bucket.bucket.id}"
+  value = "${local.bucket_id}"
 }
 
 output "region" {
-  value = "${aws_s3_bucket.bucket.region}"
+  value = "${local.bucket_region}"
 }
 
 output "config_vars" {
   value = {
     STORAGE_DRIVER = "s3"
-    S3_REGION      = "${aws_s3_bucket.bucket.region}"
-    S3_BUCKET      = "${aws_s3_bucket.bucket.id}"
+    S3_BUCKET      = "${local.bucket_id}"
+    S3_REGION      = "${local.bucket_region}"
   }
 }

--- a/shared/s3_bucket/replication-policy.json.tpl
+++ b/shared/s3_bucket/replication-policy.json.tpl
@@ -1,0 +1,33 @@
+{
+  "Version": "2012-10-17",
+  "Statement": [
+    {
+      "Action": [
+        "s3:GetReplicationConfiguration",
+        "s3:ListBucket"
+      ],
+      "Effect": "Allow",
+      "Resource": [
+        "${source_bucket_arn}"
+      ]
+    },
+    {
+      "Action": [
+        "s3:GetObjectVersion",
+        "s3:GetObjectVersionAcl"
+      ],
+      "Effect": "Allow",
+      "Resource": [
+        "${source_bucket_arn}/*"
+      ]
+    },
+    {
+      "Action": [
+        "s3:ReplicateObject",
+        "s3:ReplicateDelete"
+      ],
+      "Effect": "Allow",
+      "Resource": "${destination_bucket_arn}/*"
+    }
+  ]
+}

--- a/shared/s3_bucket/replication-role.json
+++ b/shared/s3_bucket/replication-role.json
@@ -1,0 +1,13 @@
+{
+  "Version": "2012-10-17",
+  "Statement": [
+    {
+      "Action": "sts:AssumeRole",
+      "Principal": {
+        "Service": "s3.amazonaws.com"
+      },
+      "Effect": "Allow",
+      "Sid": ""
+    }
+  ]
+}


### PR DESCRIPTION
When re-creating buckets with Terraform, I did not carry over the same versioning and cross-region replication settings. Since this is a useful backup strategy, I'd like to get this implemented before we delete the old `ds-rogue-prod` and `ds-rogue-prod-backup` buckets.