### PR TITLE
Switch to serving search endpoint from Phoenix.

### DIFF
--- a/dosomething-dev/fastly-frontend/ashes_recv.vcl
+++ b/dosomething-dev/fastly-frontend/ashes_recv.vcl
@@ -18,7 +18,7 @@ else if (req.url.path ~ "(?i)^\/index\.php$") {
   # The '/index.php' file is used by some Ashes admin pages:
   set req.http.X-Fastly-Backend = "ashes";
 }
-else if (req.url.path ~ "(?i)\/((us|mx|br)\/)?(admin|batch|image|openid\-connect|file|sites|profiles|misc|user|taxonomy|modules|search|system|themes|node|js)") {
+else if (req.url.path ~ "(?i)\/((us|mx|br)\/)?(admin|batch|image|openid\-connect|file|sites|profiles|misc|user|taxonomy|modules|system|themes|node|js)") {
   # Drupal built-in and third-party modules are served by Ashes:
   set req.http.X-Fastly-Backend = "ashes";
 }

--- a/dosomething-qa/fastly-frontend/ashes_recv.vcl
+++ b/dosomething-qa/fastly-frontend/ashes_recv.vcl
@@ -18,7 +18,7 @@ else if (req.url.path ~ "(?i)^\/index\.php$") {
   # The '/index.php' file is used by some Ashes admin pages:
   set req.http.X-Fastly-Backend = "ashes";
 }
-else if (req.url.path ~ "(?i)\/((us|mx|br)\/)?(admin|batch|image|openid\-connect|file|sites|profiles|misc|user|taxonomy|modules|search|system|themes|node|js)") {
+else if (req.url.path ~ "(?i)\/((us|mx|br)\/)?(admin|batch|image|openid\-connect|file|sites|profiles|misc|user|taxonomy|modules|system|themes|node|js)") {
   # Drupal built-in and third-party modules are served by Ashes:
   set req.http.X-Fastly-Backend = "ashes";
 }

--- a/dosomething/fastly-frontend/ashes_recv.vcl
+++ b/dosomething/fastly-frontend/ashes_recv.vcl
@@ -18,7 +18,7 @@ else if (req.url.path ~ "(?i)^\/index\.php$") {
   # The '/index.php' file is used by some Ashes admin pages:
   set req.http.X-Fastly-Backend = "ashes";
 }
-else if (req.url.path ~ "(?i)\/((us|mx|br)\/)?(admin|batch|image|openid\-connect|file|sites|profiles|misc|user|taxonomy|modules|search|system|themes|node|js)") {
+else if (req.url.path ~ "(?i)\/((us|mx|br)\/)?(admin|batch|image|openid\-connect|file|sites|profiles|misc|user|taxonomy|modules|system|themes|node|js)") {
   # Drupal built-in and third-party modules are served by Ashes:
   set req.http.X-Fastly-Backend = "ashes";
 }


### PR DESCRIPTION
This PR just switches serving the search endpoint from Phoenix instead of Ashes so that we can activate the new search bar in Phoenix!