### PR TITLE
Adding Fivetran user to MariaDB instances for Quasar replication.

### DIFF
--- a/shared/mariadb_instance/main.tf
+++ b/shared/mariadb_instance/main.tf
@@ -203,12 +203,20 @@ resource "mysql_user" "fivetran" {
   plaintext_password = "${random_string.fivetran_password.result}"
 }
 
-resource "mysql_grant" "fivetran" {
+resource "mysql_grant" "fivetran_select" {
   count      = "${var.deprecated ? 0 : 1}"
   user       = "${mysql_user.fivetran.user}"
   host       = "${mysql_user.fivetran.host}"
   database   = "${aws_db_instance.database.name}"
-  privileges = ["SELECT", "REPLICATION CLIENT", "REPLICATION SLAVE"]
+  privileges = ["SELECT"]
+}
+
+resource "mysql_grant" "fivetran_replication" {
+  count      = "${var.deprecated ? 0 : 1}"
+  user       = "${mysql_user.fivetran.user}"
+  host       = "${mysql_user.fivetran.host}"
+  database   = "*"
+  privileges = ["REPLICATION CLIENT", "REPLICATION SLAVE"]
 }
 
 output "address" {


### PR DESCRIPTION
Adding dedicated `fivetran` user to MariaDB instances so we can replicate data from Rogue QA/Prod to Quasar QA/Prod.

@DFurnes I've run the `make plan`, and the out put looks sane (as per perusing for `fivetran` related changes), but would love a 👬 for this one, since it's adding/altering DB credentials, and our state is a bit in flux with the GraphQL Lambda experiments.