### PR TITLE
Increase memory limit on Lambda functions to reduce 

### DIFF
--- a/shared/lambda_function/main.tf
+++ b/shared/lambda_function/main.tf
@@ -29,6 +29,10 @@ resource "aws_lambda_function" "function" {
 
   runtime = "nodejs8.10"
 
+  # We increase our default RAM allocation in order to
+  # decrease worst-case cold start times. <...>
+  memory_size = 512 # MB.
+
   timeout = 15
 
   environment {

--- a/shared/lambda_function/main.tf
+++ b/shared/lambda_function/main.tf
@@ -33,6 +33,8 @@ resource "aws_lambda_function" "function" {
   # decrease worst-case cold start times. <...>
   memory_size = 512 # MB.
 
+  # We set a "sane default" 15 second timeout (matching
+  # our Fastly configs) to avoid runaway requests.
   timeout = 15
 
   environment {


### PR DESCRIPTION
When researching our cold start woes from #119, I came across this [blog post](https://read.acloud.guru/does-coding-language-memory-or-package-size-affect-cold-starts-of-aws-lambda-a15e26d12c76) which suggested that boosting the amount of RAM allocated to each Lambda function would improve worst-case cold start boot times. I tested this on our own function & it checks out!

Increasing the memory on this function will adjust the price per 100ms from $0.000000208 to $0.000000834, which for an expected usage of 5M requests per month boosts the cost of this function from $0.80 to $2.46 per month. 💰 

### Methodology

For each test, I deployed a new version of our serverless function (which forces cold starts for the subsequent requests, and then ran the load test for 5 minutes with 40 concurrent "users").

```
siege -c40 -t300S --content-type "application/json" 'https://plddchi7pi.execute-api.us-east-1.amazonaws.com/development/ POST {"query":"{topic(id: \"G8LCAYO9WuGC2UW8mQi6w\") { name,  ...on AskYesNoBroadcastTopic {text,saidYes}}}"}'
```

| RAM        | Availability | Throughput | Timeouts | Avg. Response | Worst Response |
|------------|--------------|------------|----------|---------------|----------------|
| **128 MB** | 99.46%       | 96.12rps   | 156      | 0.42s         | 28.59s         |
| **256 MB** | 99.90%       | 89.3rps    | 28       | 0.25s         | 29.46s         |
| **512 MB** | 100.0%       | 263.7rps   | 1        | 0.15s         | 9.50s          |

So, as you can see, giving the Lambda function 512MB of RAM drastically reduces the impact of cold boots and in doing so dramatically increases our effective throughput, since we don't end up with a subset of clients consistently timing out.

Finally – to be sure this data wasn't a fluke, I also ran another two separate 2-minute load tests at each RAM setting & got results consistent with what's in the above table. Click in for the full nerdery:

<details>
<summary><strong>Full load test results for each memory setting</strong></summary>

#### 128MB:

##### Round 1 (2 minutes):

```
Transactions:		        1670 hits
Availability:		       93.35 %
Elapsed time:		      119.19 secs
Data transferred:	        1.32 MB
Response time:		        2.46 secs
Transaction rate:	       14.01 trans/sec
Throughput:		        0.01 MB/sec
Concurrency:		       34.50
Successful transactions:        1670
Failed transactions:	         119
Longest transaction:	       29.48
Shortest transaction:	        0.14
```

##### Round 2 (2 minutes):

```
Transactions:		        7834 hits
Availability:		       99.00 %
Elapsed time:		      119.59 secs
Data transferred:	        6.17 MB
Response time:		        0.59 secs
Transaction rate:	       65.51 trans/sec
Throughput:		        0.05 MB/sec
Concurrency:		       38.88
Successful transactions:        7835
Failed transactions:	          79
Longest transaction:	       29.45
Shortest transaction:	        0.11
```

##### Round 3 (5 minutes):

```
Transactions:		       28771 hits
Availability:		       99.46 %
Elapsed time:		      299.31 secs
Data transferred:	       22.64 MB
Response time:		        0.42 secs
Transaction rate:	       96.12 trans/sec
Throughput:		        0.08 MB/sec
Concurrency:		       39.90
Successful transactions:       28771
Failed transactions:	         156
Longest transaction:	       28.59
Shortest transaction:	        0.10
```

#### 256MB:
##### Round 1 (2 minutes):

```
Transactions:		       13571 hits
Availability:		       99.56 %
Elapsed time:		      119.25 secs
Data transferred:	       10.68 MB
Response time:		        0.34 secs
Transaction rate:	      113.80 trans/sec
Throughput:		        0.09 MB/sec
Concurrency:		       38.99
Successful transactions:       13571
Failed transactions:	          60
Longest transaction:	       28.70
Shortest transaction:	        0.07
```

##### Round 2 (2 minutes):

```
Transactions:		       17092 hits
Availability:		       99.70 %
Elapsed time:		      119.52 secs
Data transferred:	       13.45 MB
Response time:		        0.27 secs
Transaction rate:	      143.01 trans/sec
Throughput:		        0.11 MB/sec
Concurrency:		       38.97
Successful transactions:       17092
Failed transactions:	          52
Longest transaction:	       28.59
Shortest transaction:	        0.07
```

##### Round 3 (5 minutes):

```
Transactions:		       26776 hits
Availability:		       99.90 %
Elapsed time:		      299.79 secs
Data transferred:	       21.07 MB
Response time:		        0.25 secs
Transaction rate:	       89.32 trans/sec
Throughput:		        0.07 MB/sec
Concurrency:		       21.91
Successful transactions:       26776
Failed transactions:	          28
Longest transaction:	       29.46
Shortest transaction:	        0.07
```

#### 512MB:
##### Round 1 (2 minutes):

```
Lifting the server siege...
Transactions:		       26578 hits
Availability:		       99.95 %
Elapsed time:		      119.07 secs
Data transferred:	       20.91 MB
Response time:		        0.18 secs
Transaction rate:	      223.21 trans/sec
Throughput:		        0.18 MB/sec
Concurrency:		       39.66
Successful transactions:       26578
Failed transactions:	          12
Longest transaction:	        9.99
Shortest transaction:	        0.07
```

##### Round 2 (2 minutes):

```
Transactions:		       27760 hits
Availability:		      100.00 %
Elapsed time:		      119.22 secs
Data transferred:	       21.84 MB
Response time:		        0.17 secs
Transaction rate:	      232.85 trans/sec
Throughput:		        0.18 MB/sec
Concurrency:		       39.66
Successful transactions:       27760
Failed transactions:	           0
Longest transaction:	        8.83
Shortest transaction:	        0.07
```

##### Round 3 (5 minutes):

```
Transactions:		       79015 hits
Availability:		      100.00 %
Elapsed time:		      299.64 secs
Data transferred:	       62.17 MB
Response time:		        0.15 secs
Transaction rate:	      263.70 trans/sec
Throughput:		        0.21 MB/sec
Concurrency:		       39.59
Successful transactions:       79015
Failed transactions:	           1
Longest transaction:	        9.50
Shortest transaction:	        0.07
```

</details>