### PR TITLE
Fix issue diffing aws_s3_bucket_object on different machines.

### DIFF
--- a/shared/lambda_function/main.tf
+++ b/shared/lambda_function/main.tf
@@ -126,7 +126,7 @@ resource "aws_s3_bucket" "deploy" {
 resource "aws_s3_bucket_object" "release" {
   bucket = "${aws_s3_bucket.deploy.id}"
   key    = "release.zip"
-  source = "example.zip"
+  source = "./example.zip"
 }
 
 # Log group:

--- a/shared/lambda_function/main.tf
+++ b/shared/lambda_function/main.tf
@@ -126,7 +126,10 @@ resource "aws_s3_bucket" "deploy" {
 resource "aws_s3_bucket_object" "release" {
   bucket = "${aws_s3_bucket.deploy.id}"
   key    = "release.zip"
-  source = "./example.zip"
+
+  # We hard-code this module's path (from the root) here to avoid an issue
+  # where ${path.module} marks this as "dirty" on different machines.
+  source = "shared/lambda_function/example.zip"
 }
 
 # Log group:

--- a/shared/lambda_function/main.tf
+++ b/shared/lambda_function/main.tf
@@ -126,7 +126,7 @@ resource "aws_s3_bucket" "deploy" {
 resource "aws_s3_bucket_object" "release" {
   bucket = "${aws_s3_bucket.deploy.id}"
   key    = "release.zip"
-  source = "${path.module}/example.zip"
+  source = "example.zip"
 }
 
 # Log group:


### PR DESCRIPTION
This fixes an issue that @sheyd flagged where this `aws_s3_bucket_object` resource was being marked as "dirty" because it had the full filesystem path referenced in state. Oy!

```
~ module.dosomething-dev.module.graphql_lambda.module.app.aws_s3_bucket_object.release
    source:   "/Users/dfurnes/Sites/infrastructure/.terraform/modules/7098d4dc690e409165bb37a4312fdf6d/example.zip" => "/Users/sheydari/infrastructure/.terraform/modules/7098d4dc690e409165bb37a4312fdf6d/example.zip"
```

Referencing [this issue on the AWS provider](https://git.io/fh13a), I've updated `source` to be a relative path here.