### PR TITLE
Streamline CircleCI deploy pipeline setup.

### DIFF
--- a/shared/circleci-policy.json.tpl
+++ b/shared/circleci-policy.json.tpl
@@ -1,0 +1,23 @@
+{
+    "Version": "2012-10-17",
+    "Statement": [
+        {
+            "Effect": "Allow",
+            "Action": [
+                "ssm:GetParametersByPath",
+                "ssm:GetParameters",
+                "ssm:GetParameter"
+            ],
+            "Resource": "arn:aws:ssm:us-east-1:${account_id}:parameter/circleci/*"
+        },
+        {
+           "Effect":"Allow",
+           "Action":[
+              "kms:Decrypt"
+           ],
+           "Resource":[
+              "${kms_arn}"
+           ]
+        }
+    ]
+}

--- a/shared/lambda_function/main.tf
+++ b/shared/lambda_function/main.tf
@@ -194,6 +194,18 @@ resource "aws_iam_access_key" "deploy_key" {
   user = "${aws_iam_user.lambda_deploy.name}"
 }
 
+resource "aws_ssm_parameter" "ssm_access_key" {
+  name  = "/circleci/${var.name}/AWS_ACCESS_KEY_ID"
+  type  = "SecureString"
+  value = "${aws_iam_access_key.deploy_key.id}"
+}
+
+resource "aws_ssm_parameter" "ssm_secret_key" {
+  name  = "/circleci/${var.name}/AWS_SECRET_ACCESS_KEY"
+  type  = "SecureString"
+  value = "${aws_iam_access_key.deploy_key.secret}"
+}
+
 output "lambda_role" {
   value = "${aws_iam_role.lambda_exec.name}"
 }

--- a/shared/main.tf
+++ b/shared/main.tf
@@ -1,3 +1,34 @@
+data "aws_caller_identity" "current" {}
+
+data "aws_kms_alias" "default" {
+  name = "alias/aws/ssm"
+}
+
+# This is the IAM user & access key that grants CircleCI the ability
+# to read any secrets stored in the `/circleci/...` prefix in SSM.
+resource "aws_iam_user" "circleci" {
+  name = "circleci"
+}
+
+resource "aws_iam_user_policy" "circleci_policy" {
+  user   = "${aws_iam_user.circleci.name}"
+  policy = "${data.template_file.circleci_policy.rendered}"
+}
+
+data "template_file" "circleci_policy" {
+  template = "${file("${path.module}/circleci-policy.json.tpl")}"
+
+  vars {
+    kms_arn    = "${data.aws_kms_alias.default.arn}"
+    account_id = "${data.aws_caller_identity.current.account_id}"
+  }
+}
+
+resource "aws_iam_access_key" "circleci_key" {
+  user = "${aws_iam_user.circleci.name}"
+}
+
+# Heroku pipelines
 resource "heroku_pipeline" "graphql" {
   name = "graphql"
 }


### PR DESCRIPTION
This pull request provisions a `circleci` IAM user with read-only access to any SSM parameters prefixed by `/circleci/*`. This allows us to automatically configure our deploy pipeline in DoSomething/graphql#52 without needing to manually copy-and-paste credentials.