### PR TITLE
Restructuring legacy redirects

### DIFF
--- a/dosomething-dev/fastly-frontend/homepage_error.vcl
+++ b/dosomething-dev/fastly-frontend/homepage_error.vcl
@@ -11,12 +11,12 @@ if (obj.status == 778) {
   # let us simplify this.
   if (req.url ~ "^/([\?#].+)$") {
     set obj.http.Location = "/us" + re.group.1;
-    set obj.status = 302;
+    set obj.status = 301;
     return(deliver);
   }
   if (req.url ~ "^/$") {
     set obj.http.Location = "/us";
-    set obj.status = 302;
+    set obj.status = 301;
     return(deliver);
   }
 }

--- a/dosomething-dev/fastly-frontend/legacy_redirects_error.vcl
+++ b/dosomething-dev/fastly-frontend/legacy_redirects_error.vcl
@@ -1,18 +1,6 @@
 if (obj.status == 800) {
-  # Redirect requests to the homepage.
-  set obj.http.Location = "/us";
-  set obj.status = 301;
-  return (deliver);
-}
-
-if (obj.status == 810) {
-  set obj.http.Location = "/us/about/our-press";
-  set obj.status = 301;
-  return (deliver);
-}
-
-if (obj.status == 811) {
-  set obj.http.Location = "/us/about/our-people";
+  # Redirect requests to the specified path.
+  set obj.http.Location = obj.response;
   set obj.status = 301;
   return (deliver);
 }

--- a/dosomething-dev/fastly-frontend/legacy_redirects_error.vcl
+++ b/dosomething-dev/fastly-frontend/legacy_redirects_error.vcl
@@ -1,0 +1,18 @@
+if (obj.status == 800) {
+  # Redirect requests to the homepage.
+  set obj.http.Location = "/us";
+  set obj.status = 301;
+  return (deliver);
+}
+
+if (obj.status == 810) {
+  set obj.http.Location = "/us/about/our-press";
+  set obj.status = 301;
+  return (deliver);
+}
+
+if (obj.status == 811) {
+  set obj.http.Location = "/us/about/our-people";
+  set obj.status = 301;
+  return (deliver);
+}

--- a/dosomething-dev/fastly-frontend/legacy_redirects_recv.vcl
+++ b/dosomething-dev/fastly-frontend/legacy_redirects_recv.vcl
@@ -1,14 +1,14 @@
 # Redirect */actnow/* page requests.
-if (req.url ~ "(?i)^\/((us|mx|br)\/)?actnow\/") { error 800 "Not Found"; }
+if (req.url ~ "(?i)^\/((us|mx|br)\/)?actnow\/") { error 800 "/us"; }
 
 # Redirect */programs/* page requests.
-if (req.url ~ "(?i)^\/((us|mx|br)\/)?programs\/") { error 800 "Not Found"; }
+if (req.url ~ "(?i)^\/((us|mx|br)\/)?programs\/") { error 800 "/us"; }
   
 # Redirect */project/* page requests.
-if (req.url ~ "(?i)^\/((us|mx|br)\/)?project(s)?\/") { error 800 "Not Found"; }
+if (req.url ~ "(?i)^\/((us|mx|br)\/)?project(s)?\/") { error 800 "/us"; }
 
 # Redirect */about/press/* page requests.
-if (req.url ~ "(?i)^\/((us|mx|br)\/)?about\/press\/") { error 810 "Not Found"; }
+if (req.url ~ "(?i)^\/((us|mx|br)\/)?about\/press\/") { error 800 "/us/about/our-press"; }
 
 # Redirect */about/team/* page requests.
-if (req.url ~ "(?i)^\/((us|mx|br)\/)?about\/team\/") { error 811 "Not Found"; }
+if (req.url ~ "(?i)^\/((us|mx|br)\/)?about\/team\/") { error 800 "/us/about/our-people"; }

--- a/dosomething-dev/fastly-frontend/legacy_redirects_recv.vcl
+++ b/dosomething-dev/fastly-frontend/legacy_redirects_recv.vcl
@@ -1,0 +1,14 @@
+# Redirect */actnow/* page requests.
+if (req.url ~ "(?i)^\/((us|mx|br)\/)?actnow\/") { error 800 "Not Found"; }
+
+# Redirect */programs/* page requests.
+if (req.url ~ "(?i)^\/((us|mx|br)\/)?programs\/") { error 800 "Not Found"; }
+  
+# Redirect */project/* page requests.
+if (req.url ~ "(?i)^\/((us|mx|br)\/)?project(s)?\/") { error 800 "Not Found"; }
+
+# Redirect */about/press/* page requests.
+if (req.url ~ "(?i)^\/((us|mx|br)\/)?about\/press\/") { error 810 "Not Found"; }
+
+# Redirect */about/team/* page requests.
+if (req.url ~ "(?i)^\/((us|mx|br)\/)?about\/team\/") { error 811 "Not Found"; }

--- a/dosomething-dev/fastly-frontend/main.tf
+++ b/dosomething-dev/fastly-frontend/main.tf
@@ -119,6 +119,8 @@ resource "fastly_service_v1" "frontend-dev" {
     name    = "Frontend - Trigger Redirect"
     type    = "recv"
     content = "${file("${path.module}/redirect_recv.vcl")}"
+
+    priority = 10 # Specifying priority so Aurora redirects take precedence.
   }
 
   snippet {

--- a/dosomething-dev/fastly-frontend/main.tf
+++ b/dosomething-dev/fastly-frontend/main.tf
@@ -132,13 +132,13 @@ resource "fastly_service_v1" "frontend-dev" {
   snippet {
     name    = "ProjectPages - Trigger Redirect"
     type    = "recv"
-    content = "${file("${path.module}/projectpages_recv.vcl")}"
+    content = "${file("${path.module}/legacy_redirects_recv.vcl")}"
   }
 
   snippet {
     name    = "ProjectPages - Handle Redirect"
     type    = "error"
-    content = "${file("${path.module}/projectpages_error.vcl")}"
+    content = "${file("${path.module}/legacy_redirects_error.vcl")}"
   }
 
   snippet {

--- a/dosomething-dev/fastly-frontend/projectpages_error.vcl
+++ b/dosomething-dev/fastly-frontend/projectpages_error.vcl
@@ -1,6 +1,0 @@
-if (obj.status == 779) {
-  # Redirect any requests to */project/* and send them to the homepage.
-  set obj.http.Location = "/us";
-  set obj.status = 302;
-  return (deliver);
-}

--- a/dosomething-dev/fastly-frontend/projectpages_recv.vcl
+++ b/dosomething-dev/fastly-frontend/projectpages_recv.vcl
@@ -1,4 +1,0 @@
-# Catch any */project/* page requests.
-if (req.url ~ "(?i)^\/((us|mx|br)\/)?project\/") {
-  error 779 "Not Found";
-}

--- a/dosomething-qa/fastly-frontend/homepage_error.vcl
+++ b/dosomething-qa/fastly-frontend/homepage_error.vcl
@@ -11,12 +11,12 @@ if (obj.status == 778) {
   # let us simplify this.
   if (req.url ~ "^/([\?#].+)$") {
     set obj.http.Location = "/us" + re.group.1;
-    set obj.status = 302;
+    set obj.status = 301;
     return(deliver);
   }
   if (req.url ~ "^/$") {
     set obj.http.Location = "/us";
-    set obj.status = 302;
+    set obj.status = 301;
     return(deliver);
   }
 }

--- a/dosomething-qa/fastly-frontend/legacy_redirects_error.vcl
+++ b/dosomething-qa/fastly-frontend/legacy_redirects_error.vcl
@@ -1,18 +1,6 @@
 if (obj.status == 800) {
-  # Redirect requests to the homepage.
-  set obj.http.Location = "/us";
-  set obj.status = 301;
-  return (deliver);
-}
-
-if (obj.status == 810) {
-  set obj.http.Location = "/us/about/our-press";
-  set obj.status = 301;
-  return (deliver);
-}
-
-if (obj.status == 811) {
-  set obj.http.Location = "/us/about/our-people";
+  # Redirect requests to the specified path.
+  set obj.http.Location = obj.response;
   set obj.status = 301;
   return (deliver);
 }

--- a/dosomething-qa/fastly-frontend/legacy_redirects_error.vcl
+++ b/dosomething-qa/fastly-frontend/legacy_redirects_error.vcl
@@ -1,0 +1,18 @@
+if (obj.status == 800) {
+  # Redirect requests to the homepage.
+  set obj.http.Location = "/us";
+  set obj.status = 301;
+  return (deliver);
+}
+
+if (obj.status == 810) {
+  set obj.http.Location = "/us/about/our-press";
+  set obj.status = 301;
+  return (deliver);
+}
+
+if (obj.status == 811) {
+  set obj.http.Location = "/us/about/our-people";
+  set obj.status = 301;
+  return (deliver);
+}

--- a/dosomething-qa/fastly-frontend/legacy_redirects_recv.vcl
+++ b/dosomething-qa/fastly-frontend/legacy_redirects_recv.vcl
@@ -1,14 +1,14 @@
 # Redirect */actnow/* page requests.
-if (req.url ~ "(?i)^\/((us|mx|br)\/)?actnow\/") { error 800 "Not Found"; }
+if (req.url ~ "(?i)^\/((us|mx|br)\/)?actnow\/") { error 800 "/us"; }
 
 # Redirect */programs/* page requests.
-if (req.url ~ "(?i)^\/((us|mx|br)\/)?programs\/") { error 800 "Not Found"; }
+if (req.url ~ "(?i)^\/((us|mx|br)\/)?programs\/") { error 800 "/us"; }
   
 # Redirect */project/* page requests.
-if (req.url ~ "(?i)^\/((us|mx|br)\/)?project(s)?\/") { error 800 "Not Found"; }
+if (req.url ~ "(?i)^\/((us|mx|br)\/)?project(s)?\/") { error 800 "/us"; }
 
 # Redirect */about/press/* page requests.
-if (req.url ~ "(?i)^\/((us|mx|br)\/)?about\/press\/") { error 810 "Not Found"; }
+if (req.url ~ "(?i)^\/((us|mx|br)\/)?about\/press\/") { error 800 "/us/about/our-press"; }
 
 # Redirect */about/team/* page requests.
-if (req.url ~ "(?i)^\/((us|mx|br)\/)?about\/team\/") { error 811 "Not Found"; }
+if (req.url ~ "(?i)^\/((us|mx|br)\/)?about\/team\/") { error 800 "/us/about/our-people"; }

--- a/dosomething-qa/fastly-frontend/legacy_redirects_recv.vcl
+++ b/dosomething-qa/fastly-frontend/legacy_redirects_recv.vcl
@@ -1,0 +1,14 @@
+# Redirect */actnow/* page requests.
+if (req.url ~ "(?i)^\/((us|mx|br)\/)?actnow\/") { error 800 "Not Found"; }
+
+# Redirect */programs/* page requests.
+if (req.url ~ "(?i)^\/((us|mx|br)\/)?programs\/") { error 800 "Not Found"; }
+  
+# Redirect */project/* page requests.
+if (req.url ~ "(?i)^\/((us|mx|br)\/)?project(s)?\/") { error 800 "Not Found"; }
+
+# Redirect */about/press/* page requests.
+if (req.url ~ "(?i)^\/((us|mx|br)\/)?about\/press\/") { error 810 "Not Found"; }
+
+# Redirect */about/team/* page requests.
+if (req.url ~ "(?i)^\/((us|mx|br)\/)?about\/team\/") { error 811 "Not Found"; }

--- a/dosomething-qa/fastly-frontend/main.tf
+++ b/dosomething-qa/fastly-frontend/main.tf
@@ -131,6 +131,8 @@ resource "fastly_service_v1" "frontend-qa" {
     name    = "Frontend - Trigger Redirect"
     type    = "recv"
     content = "${file("${path.module}/redirect_recv.vcl")}"
+
+    priority = 10 # Specifying priority so Aurora redirects take precedence.
   }
 
   snippet {
@@ -142,13 +144,13 @@ resource "fastly_service_v1" "frontend-qa" {
   snippet {
     name    = "ProjectPages - Trigger Redirect"
     type    = "recv"
-    content = "${file("${path.module}/projectpages_recv.vcl")}"
+    content = "${file("${path.module}/legacy_redirects_recv.vcl")}"
   }
 
   snippet {
     name    = "ProjectPages - Handle Redirect"
     type    = "error"
-    content = "${file("${path.module}/projectpages_error.vcl")}"
+    content = "${file("${path.module}/legacy_redirects_error.vcl")}"
   }
 
   snippet {

--- a/dosomething-qa/fastly-frontend/projectpages_error.vcl
+++ b/dosomething-qa/fastly-frontend/projectpages_error.vcl
@@ -1,6 +1,0 @@
-if (obj.status == 779) {
-  # Redirect any requests to */project/* and send them to the homepage.
-  set obj.http.Location = "/us";
-  set obj.status = 302;
-  return (deliver);
-}

--- a/dosomething-qa/fastly-frontend/projectpages_recv.vcl
+++ b/dosomething-qa/fastly-frontend/projectpages_recv.vcl
@@ -1,4 +1,0 @@
-# Catch any */project/* page requests.
-if (req.url ~ "(?i)^\/((us|mx|br)\/)?project(s)?\/") {
-  error 779 "Not Found";
-}

--- a/dosomething-qa/fastly-frontend/projectpages_recv.vcl
+++ b/dosomething-qa/fastly-frontend/projectpages_recv.vcl
@@ -1,4 +1,4 @@
 # Catch any */project/* page requests.
-if (req.url ~ "(?i)^\/((us|mx|br)\/)?project\/") {
+if (req.url ~ "(?i)^\/((us|mx|br)\/)?project(s)?\/") {
   error 779 "Not Found";
 }

--- a/dosomething/fastly-frontend/homepage_error.vcl
+++ b/dosomething/fastly-frontend/homepage_error.vcl
@@ -11,12 +11,12 @@ if (obj.status == 778) {
   # let us simplify this.
   if (req.url ~ "^/([\?#].+)$") {
     set obj.http.Location = "/us" + re.group.1;
-    set obj.status = 302;
+    set obj.status = 301;
     return(deliver);
   }
   if (req.url ~ "^/$") {
     set obj.http.Location = "/us";
-    set obj.status = 302;
+    set obj.status = 301;
     return(deliver);
   }
 }

--- a/dosomething/fastly-frontend/legacy_redirects_error.vcl
+++ b/dosomething/fastly-frontend/legacy_redirects_error.vcl
@@ -1,18 +1,6 @@
 if (obj.status == 800) {
-  # Redirect requests to the homepage.
-  set obj.http.Location = "/us";
-  set obj.status = 301;
-  return (deliver);
-}
-
-if (obj.status == 810) {
-  set obj.http.Location = "/us/about/our-press";
-  set obj.status = 301;
-  return (deliver);
-}
-
-if (obj.status == 811) {
-  set obj.http.Location = "/us/about/our-people";
+  # Redirect requests to the specified path.
+  set obj.http.Location = obj.response;
   set obj.status = 301;
   return (deliver);
 }

--- a/dosomething/fastly-frontend/legacy_redirects_error.vcl
+++ b/dosomething/fastly-frontend/legacy_redirects_error.vcl
@@ -1,0 +1,18 @@
+if (obj.status == 800) {
+  # Redirect requests to the homepage.
+  set obj.http.Location = "/us";
+  set obj.status = 301;
+  return (deliver);
+}
+
+if (obj.status == 810) {
+  set obj.http.Location = "/us/about/our-press";
+  set obj.status = 301;
+  return (deliver);
+}
+
+if (obj.status == 811) {
+  set obj.http.Location = "/us/about/our-people";
+  set obj.status = 301;
+  return (deliver);
+}

--- a/dosomething/fastly-frontend/legacy_redirects_recv.vcl
+++ b/dosomething/fastly-frontend/legacy_redirects_recv.vcl
@@ -1,14 +1,14 @@
 # Redirect */actnow/* page requests.
-if (req.url ~ "(?i)^\/((us|mx|br)\/)?actnow\/") { error 800 "Not Found"; }
+if (req.url ~ "(?i)^\/((us|mx|br)\/)?actnow\/") { error 800 "/us"; }
 
 # Redirect */programs/* page requests.
-if (req.url ~ "(?i)^\/((us|mx|br)\/)?programs\/") { error 800 "Not Found"; }
+if (req.url ~ "(?i)^\/((us|mx|br)\/)?programs\/") { error 800 "/us"; }
   
 # Redirect */project/* page requests.
-if (req.url ~ "(?i)^\/((us|mx|br)\/)?project(s)?\/") { error 800 "Not Found"; }
+if (req.url ~ "(?i)^\/((us|mx|br)\/)?project(s)?\/") { error 800 "/us"; }
 
 # Redirect */about/press/* page requests.
-if (req.url ~ "(?i)^\/((us|mx|br)\/)?about\/press\/") { error 810 "Not Found"; }
+if (req.url ~ "(?i)^\/((us|mx|br)\/)?about\/press\/") { error 800 "/us/about/our-press"; }
 
 # Redirect */about/team/* page requests.
-if (req.url ~ "(?i)^\/((us|mx|br)\/)?about\/team\/") { error 811 "Not Found"; }
+if (req.url ~ "(?i)^\/((us|mx|br)\/)?about\/team\/") { error 800 "/us/about/our-people"; }

--- a/dosomething/fastly-frontend/legacy_redirects_recv.vcl
+++ b/dosomething/fastly-frontend/legacy_redirects_recv.vcl
@@ -1,0 +1,14 @@
+# Redirect */actnow/* page requests.
+if (req.url ~ "(?i)^\/((us|mx|br)\/)?actnow\/") { error 800 "Not Found"; }
+
+# Redirect */programs/* page requests.
+if (req.url ~ "(?i)^\/((us|mx|br)\/)?programs\/") { error 800 "Not Found"; }
+  
+# Redirect */project/* page requests.
+if (req.url ~ "(?i)^\/((us|mx|br)\/)?project(s)?\/") { error 800 "Not Found"; }
+
+# Redirect */about/press/* page requests.
+if (req.url ~ "(?i)^\/((us|mx|br)\/)?about\/press\/") { error 810 "Not Found"; }
+
+# Redirect */about/team/* page requests.
+if (req.url ~ "(?i)^\/((us|mx|br)\/)?about\/team\/") { error 811 "Not Found"; }

--- a/dosomething/fastly-frontend/main.tf
+++ b/dosomething/fastly-frontend/main.tf
@@ -132,13 +132,13 @@ resource "fastly_service_v1" "frontend" {
   snippet {
     name    = "ProjectPages - Trigger Redirect"
     type    = "recv"
-    content = "${file("${path.module}/projectpages_recv.vcl")}"
+    content = "${file("${path.module}/legacy_redirects_recv.vcl")}"
   }
 
   snippet {
     name    = "ProjectPages - Handle Redirect"
     type    = "error"
-    content = "${file("${path.module}/projectpages_error.vcl")}"
+    content = "${file("${path.module}/legacy_redirects_error.vcl")}"
   }
 
   snippet {

--- a/dosomething/fastly-frontend/main.tf
+++ b/dosomething/fastly-frontend/main.tf
@@ -119,6 +119,8 @@ resource "fastly_service_v1" "frontend" {
     name    = "Frontend - Trigger Redirect"
     type    = "recv"
     content = "${file("${path.module}/redirect_recv.vcl")}"
+
+    priority = 10 # Specifying priority so Aurora redirects take precedence.
   }
 
   snippet {

--- a/dosomething/fastly-frontend/projectpages_error.vcl
+++ b/dosomething/fastly-frontend/projectpages_error.vcl
@@ -1,6 +1,0 @@
-if (obj.status == 779) {
-  # Redirect any requests to */project/* and send them to the homepage.
-  set obj.http.Location = "/us";
-  set obj.status = 302;
-  return (deliver);
-}

--- a/dosomething/fastly-frontend/projectpages_recv.vcl
+++ b/dosomething/fastly-frontend/projectpages_recv.vcl
@@ -1,4 +1,0 @@
-# Catch any */project/* page requests.
-if (req.url ~ "(?i)^\/((us|mx|br)\/)?project\/") {
-  error 779 "Not Found";
-}


### PR DESCRIPTION
This PR updates the `projectpages` snippets, renaming them to `legacy_redirects`, and includes a few more redirects.

All legacy related redirects will be `8xx` errors, with `800` being a redirect to the homepage.

This also updates some redirects which have their status set to `302` to be `301` instead, based on some IRL convos with @DFurnes @ngjo and @mshmsh5000 🤝 