### PR TITLE
Add custom domain support to API Gateway module.

### DIFF
--- a/applications/graphql-lambda/main.tf
+++ b/applications/graphql-lambda/main.tf
@@ -8,8 +8,9 @@ variable "name" {
   description = "The application name."
 }
 
-variable "papertrail_destination" {
-  description = "The Papertrail log destination for this application."
+variable "domain" {
+  description = "The domain this application will be accessible at, e.g. graphql-lambda.dosomething.org"
+  default     = ""
 }
 
 data "aws_ssm_parameter" "contentful_gambit_space_id" {
@@ -74,6 +75,7 @@ module "gateway" {
   environment         = "${var.environment}"
   function_arn        = "${module.app.arn}"
   function_invoke_arn = "${module.app.invoke_arn}"
+  domain              = "${var.domain}"
 }
 
 module "cache" {

--- a/dosomething-dev/main.tf
+++ b/dosomething-dev/main.tf
@@ -51,9 +51,9 @@ module "graphql" {
 module "graphql_lambda" {
   source = "../applications/graphql-lambda"
 
-  environment            = "development"
-  name                   = "dosomething-graphql-dev"
-  papertrail_destination = "${var.papertrail_destination}"
+  environment = "development"
+  name        = "dosomething-graphql-dev"
+  domain      = "graphql-lambda-dev.dosomething.org"
 }
 
 module "northstar" {

--- a/dosomething-qa/main.tf
+++ b/dosomething-qa/main.tf
@@ -47,9 +47,10 @@ module "graphql" {
 module "graphql_lambda" {
   source = "../applications/graphql-lambda"
 
-  environment            = "qa"
-  name                   = "dosomething-graphql-qa"
-  papertrail_destination = "${var.papertrail_destination}"
+  environment = "qa"
+  name        = "dosomething-graphql-qa"
+
+  # domain      = "graphql-lambda-qa.dosomething.org"
 }
 
 module "northstar" {

--- a/dosomething-qa/main.tf
+++ b/dosomething-qa/main.tf
@@ -49,8 +49,7 @@ module "graphql_lambda" {
 
   environment = "qa"
   name        = "dosomething-graphql-qa"
-
-  # domain      = "graphql-lambda-qa.dosomething.org"
+  domain      = "graphql-lambda-qa.dosomething.org"
 }
 
 module "northstar" {

--- a/dosomething/main.tf
+++ b/dosomething/main.tf
@@ -53,8 +53,7 @@ module "graphql_lambda" {
 
   environment = "production"
   name        = "dosomething-graphql"
-
-  # domain      = "graphql-lambda.dosomething.org"
+  domain      = "graphql-lambda.dosomething.org"
 }
 
 module "northstar" {

--- a/dosomething/main.tf
+++ b/dosomething/main.tf
@@ -51,9 +51,10 @@ module "graphql" {
 module "graphql_lambda" {
   source = "../applications/graphql-lambda"
 
-  environment            = "production"
-  name                   = "dosomething-graphql"
-  papertrail_destination = "${var.papertrail_destination}"
+  environment = "production"
+  name        = "dosomething-graphql"
+
+  # domain      = "graphql-lambda.dosomething.org"
 }
 
 module "northstar" {

--- a/shared/api_gateway_proxy/main.tf
+++ b/shared/api_gateway_proxy/main.tf
@@ -114,18 +114,14 @@ resource "aws_api_gateway_domain_name" "domain" {
 
   certificate_arn = "${data.aws_acm_certificate.certificate.arn}"
   domain_name     = "${var.domain}"
-
-  endpoint_configuration {
-    types = ["REGIONAL"]
-  }
 }
 
-resource "aws_api_gateway_base_path_mapping" "test" {
+resource "aws_api_gateway_base_path_mapping" "mapping" {
   count = "${var.domain == "" ? 0 : 1}"
 
   api_id      = "${aws_api_gateway_rest_api.gateway.id}"
   stage_name  = "${aws_api_gateway_deployment.deployment.stage_name}"
-  domain_name = "${var.domain}"
+  domain_name = "${aws_api_gateway_domain_name.domain.domain_name}"
 }
 
 output "base_url" {

--- a/shared/api_gateway_proxy/main.tf
+++ b/shared/api_gateway_proxy/main.tf
@@ -114,6 +114,10 @@ resource "aws_api_gateway_domain_name" "domain" {
 
   certificate_arn = "${data.aws_acm_certificate.certificate.arn}"
   domain_name     = "${var.domain}"
+
+  endpoint_configuration {
+    types = ["REGIONAL"]
+  }
 }
 
 resource "aws_api_gateway_base_path_mapping" "test" {

--- a/shared/api_gateway_proxy/main.tf
+++ b/shared/api_gateway_proxy/main.tf
@@ -15,6 +15,15 @@ variable "function_invoke_arn" {
   description = "The Lambda function's invocation ARN."
 }
 
+# Optional variables:
+variable "domain" {
+  description = "The domain this application will be accessible at, e.g. lambda.dosomething.org"
+
+  # If omitted, we will just not attach a custom domain to this app. By default,
+  # you can access a Lambda function at a URL returned in the `base_url` output.
+  default = ""
+}
+
 resource "aws_api_gateway_rest_api" "gateway" {
   name        = "${var.name}"
   description = "Managed with Terraform."

--- a/shared/api_gateway_proxy/main.tf
+++ b/shared/api_gateway_proxy/main.tf
@@ -109,6 +109,21 @@ data "aws_acm_certificate" "certificate" {
   statuses = ["ISSUED"]
 }
 
+resource "aws_api_gateway_domain_name" "domain" {
+  count = "${var.domain == "" ? 0 : 1}"
+
+  certificate_arn = "${data.aws_acm_certificate.certificate.arn}"
+  domain_name     = "${var.domain}"
+}
+
+resource "aws_api_gateway_base_path_mapping" "test" {
+  count = "${var.domain == "" ? 0 : 1}"
+
+  api_id      = "${aws_api_gateway_rest_api.gateway.id}"
+  stage_name  = "${aws_api_gateway_deployment.deployment.stage_name}"
+  domain_name = "${var.domain}"
+}
+
 output "base_url" {
   value = "${aws_api_gateway_deployment.deployment.invoke_url}"
 }

--- a/shared/api_gateway_proxy/main.tf
+++ b/shared/api_gateway_proxy/main.tf
@@ -125,5 +125,5 @@ resource "aws_api_gateway_base_path_mapping" "mapping" {
 }
 
 output "base_url" {
-  value = "${aws_api_gateway_deployment.deployment.invoke_url}"
+  value = "${var.domain == "" ? aws_api_gateway_deployment.deployment.invoke_url : "https://${var.domain}"}"
 }


### PR DESCRIPTION
This pull request adds support for attaching a custom domain to an API Gateway stage. For now, I'm just importing our existing wildcard certificate using the [`aws_acm_certificate`](`https://www.terraform.io/docs/providers/aws/d/acm_certificate.html) data resource (since we don't use Route53 and DNSMadeEasy's provider is [kaput](https://github.com/DoSomething/infrastructure/issues/11#issuecomment-460815237)).