### PR TITLE
Forward logs to Papertrail for Terraform-provisioned Lambdas.

### DIFF
--- a/applications/graphql-lambda/main.tf
+++ b/applications/graphql-lambda/main.tf
@@ -1,5 +1,6 @@
 # Experimental: This module builds a serverless GraphQL instance.
 
+# Required variables:
 variable "environment" {
   description = "The environment for this application: development, qa, or production."
 }
@@ -8,8 +9,14 @@ variable "name" {
   description = "The application name."
 }
 
+# Optional variables:
 variable "domain" {
   description = "The domain this application will be accessible at, e.g. graphql-lambda.dosomething.org"
+  default     = ""
+}
+
+variable "logger" {
+  description = "The Lambda function ARN to subscribe to this function's log group."
   default     = ""
 }
 

--- a/applications/graphql-lambda/main.tf
+++ b/applications/graphql-lambda/main.tf
@@ -55,6 +55,7 @@ module "app" {
 
   name        = "${var.name}"
   environment = "${var.environment}"
+  logger      = "${var.logger}"
 
   config_vars = {
     # TODO: Update application to expect 'development' here.

--- a/applications/papertrail/main.tf
+++ b/applications/papertrail/main.tf
@@ -1,0 +1,27 @@
+variable "environment" {
+  description = "The environment for this application: development, qa, or production."
+}
+
+variable "name" {
+  description = "The application name."
+}
+
+variable "papertrail_destination" {
+  description = "The Papertrail log destination to forward to."
+}
+
+module "forwarder" {
+  source = "../../shared/lambda_function"
+
+  name        = "${var.name}"
+  environment = "${var.environment}"
+
+  config_vars = {
+    PAPERTRAIL_HOST = "${element(split(":", var.papertrail_destination), 0)}"
+    PAPERTRAIL_PORT = "${element(split(":", var.papertrail_destination), 1)}"
+  }
+}
+
+output "arn" {
+  value = "${module.forwarder.arn}"
+}

--- a/applications/papertrail/main.tf
+++ b/applications/papertrail/main.tf
@@ -22,6 +22,21 @@ module "forwarder" {
   }
 }
 
+resource "aws_lambda_permission" "allow_cloudwatch" {
+  statement_id  = "AllowExecutionFromCloudWatch"
+  action        = "lambda:InvokeFunction"
+  function_name = "${module.forwarder.name}"
+  principal     = "events.amazonaws.com"
+  source_arn    = "arn:aws:events:eu-west-1:111122223333:rule/RunDaily"
+  qualifier     = "${aws_lambda_alias.latest.name}"
+}
+
+resource "aws_lambda_alias" "latest" {
+  name             = "latest"
+  function_name    = "${module.forwarder.name}"
+  function_version = "$LATEST"
+}
+
 output "arn" {
   value = "${module.forwarder.arn}"
 }

--- a/applications/papertrail/main.tf
+++ b/applications/papertrail/main.tf
@@ -10,8 +10,6 @@ variable "papertrail_destination" {
   description = "The Papertrail log destination to forward to."
 }
 
-data "aws_caller_identity" "current" {}
-
 module "forwarder" {
   source = "../../shared/lambda_function"
 
@@ -28,15 +26,7 @@ resource "aws_lambda_permission" "allow_cloudwatch" {
   statement_id  = "AllowExecutionFromCloudWatch"
   action        = "lambda:InvokeFunction"
   function_name = "${module.forwarder.name}"
-  principal     = "events.amazonaws.com"
-  source_arn    = "arn:aws:events:us-east-1:${data.aws_caller_identity.current.account_id}:rule/*"
-  qualifier     = "${aws_lambda_alias.latest.name}"
-}
-
-resource "aws_lambda_alias" "latest" {
-  name             = "latest"
-  function_name    = "${module.forwarder.name}"
-  function_version = "$LATEST"
+  principal     = "logs.us-east-1.amazonaws.com"
 }
 
 output "arn" {

--- a/applications/papertrail/main.tf
+++ b/applications/papertrail/main.tf
@@ -15,6 +15,7 @@ module "forwarder" {
 
   name        = "${var.name}"
   environment = "${var.environment}"
+  handler     = "handler.log"
 
   config_vars = {
     PAPERTRAIL_HOST = "${element(split(":", var.papertrail_destination), 0)}"

--- a/applications/papertrail/main.tf
+++ b/applications/papertrail/main.tf
@@ -10,6 +10,8 @@ variable "papertrail_destination" {
   description = "The Papertrail log destination to forward to."
 }
 
+data "aws_caller_identity" "current" {}
+
 module "forwarder" {
   source = "../../shared/lambda_function"
 
@@ -27,7 +29,7 @@ resource "aws_lambda_permission" "allow_cloudwatch" {
   action        = "lambda:InvokeFunction"
   function_name = "${module.forwarder.name}"
   principal     = "events.amazonaws.com"
-  source_arn    = "arn:aws:events:eu-west-1:111122223333:rule/RunDaily"
+  source_arn    = "arn:aws:events:us-east-1:${data.aws_caller_identity.current.account_id}:rule/*"
   qualifier     = "${aws_lambda_alias.latest.name}"
 }
 

--- a/applications/papertrail/main.tf
+++ b/applications/papertrail/main.tf
@@ -22,13 +22,6 @@ module "forwarder" {
   }
 }
 
-resource "aws_lambda_permission" "allow_cloudwatch" {
-  statement_id  = "AllowExecutionFromCloudWatch"
-  action        = "lambda:InvokeFunction"
-  function_name = "${module.forwarder.name}"
-  principal     = "logs.us-east-1.amazonaws.com"
-}
-
 output "arn" {
   value = "${module.forwarder.arn}"
 }

--- a/dosomething-dev/main.tf
+++ b/dosomething-dev/main.tf
@@ -54,6 +54,7 @@ module "graphql_lambda" {
   environment = "development"
   name        = "dosomething-graphql-dev"
   domain      = "graphql-lambda-dev.dosomething.org"
+  logger      = "${module.papertrail.arn}"
 }
 
 module "northstar" {
@@ -83,6 +84,14 @@ module "rogue" {
   name                   = "dosomething-rogue-dev"
   domain                 = "activity-dev.dosomething.org"
   pipeline               = "${var.rogue_pipeline}"
+  papertrail_destination = "${var.papertrail_destination}"
+}
+
+module "papertrail" {
+  source = "../applications/papertrail"
+
+  environment            = "development"
+  name                   = "papertrail-dev"
   papertrail_destination = "${var.papertrail_destination}"
 }
 

--- a/dosomething-qa/main.tf
+++ b/dosomething-qa/main.tf
@@ -50,6 +50,7 @@ module "graphql_lambda" {
   environment = "qa"
   name        = "dosomething-graphql-qa"
   domain      = "graphql-lambda-qa.dosomething.org"
+  logger      = "${module.papertrail.arn}"
 }
 
 module "northstar" {
@@ -79,6 +80,14 @@ module "rogue" {
   name                   = "dosomething-rogue-qa"
   domain                 = "activity-qa.dosomething.org"
   pipeline               = "${var.rogue_pipeline}"
+  papertrail_destination = "${var.papertrail_destination}"
+}
+
+module "papertrail" {
+  source = "../applications/papertrail"
+
+  environment            = "qa"
+  name                   = "papertrail-qa"
   papertrail_destination = "${var.papertrail_destination}"
 }
 

--- a/dosomething/main.tf
+++ b/dosomething/main.tf
@@ -54,6 +54,7 @@ module "graphql_lambda" {
   environment = "production"
   name        = "dosomething-graphql"
   domain      = "graphql-lambda.dosomething.org"
+  logger      = "${module.papertrail.arn}"
 }
 
 module "northstar" {
@@ -96,6 +97,14 @@ module "rogue" {
   name                   = "dosomething-rogue"
   domain                 = "activity.dosomething.org"
   pipeline               = "${var.rogue_pipeline}"
+  papertrail_destination = "${var.papertrail_destination}"
+}
+
+module "papertrail" {
+  source = "../applications/papertrail"
+
+  environment            = "production"
+  name                   = "papertrail"
   papertrail_destination = "${var.papertrail_destination}"
 }
 

--- a/shared/lambda_function/main.tf
+++ b/shared/lambda_function/main.tf
@@ -142,6 +142,10 @@ resource "aws_ssm_parameter" "ssm_secret_key" {
   value = "${aws_iam_access_key.deploy_key.secret}"
 }
 
+output "name" {
+  value = "${aws_lambda_function.function.function_name}"
+}
+
 output "arn" {
   value = "${aws_lambda_function.function.arn}"
 }

--- a/shared/lambda_function/main.tf
+++ b/shared/lambda_function/main.tf
@@ -79,16 +79,16 @@ resource "aws_cloudwatch_log_group" "log_group" {
   retention_in_days = 14
 }
 
-# resource "aws_cloudwatch_log_subscription_filter" "papertrail_subscription" {
-#   count = "${var.logger == "" ? 0 : 1}"
+resource "aws_cloudwatch_log_subscription_filter" "papertrail_subscription" {
+  count = "${var.logger == "" ? 0 : 1}"
 
-#   name            = "papertrail_forwarder"
-#   log_group_name  = "${aws_cloudwatch_log_group.log_group.name}"
-#   destination_arn = "${var.logger}"
+  name            = "papertrail_forwarder"
+  log_group_name  = "${aws_cloudwatch_log_group.log_group.name}"
+  destination_arn = "${var.logger}"
 
-#   # Forward all log messages:
-#   filter_pattern = ""
-# }
+  # Forward all log messages:
+  filter_pattern = ""
+}
 
 # This is the "execution" role that is used to run this function:
 resource "aws_iam_role" "lambda_exec" {

--- a/shared/lambda_function/main.tf
+++ b/shared/lambda_function/main.tf
@@ -90,6 +90,16 @@ resource "aws_cloudwatch_log_subscription_filter" "papertrail_subscription" {
   filter_pattern = ""
 }
 
+resource "aws_lambda_permission" "allow_cloudwatch" {
+  count = "${var.logger == "" ? 0 : 1}"
+
+  statement_id  = "AllowExecutionFromCloudWatch"
+  action        = "lambda:InvokeFunction"
+  function_name = "${var.logger}"
+  principal     = "logs.us-east-1.amazonaws.com"
+  source_arn    = "${aws_cloudwatch_log_group.log_group.arn}"
+}
+
 # This is the "execution" role that is used to run this function:
 resource "aws_iam_role" "lambda_exec" {
   name = "${var.name}"

--- a/shared/lambda_function/main.tf
+++ b/shared/lambda_function/main.tf
@@ -79,16 +79,16 @@ resource "aws_cloudwatch_log_group" "log_group" {
   retention_in_days = 14
 }
 
-resource "aws_cloudwatch_log_subscription_filter" "papertrail_subscription" {
-  count = "${var.logger == "" ? 0 : 1}"
+# resource "aws_cloudwatch_log_subscription_filter" "papertrail_subscription" {
+#   count = "${var.logger == "" ? 0 : 1}"
 
-  name            = "papertrail_forwarder"
-  log_group_name  = "${aws_cloudwatch_log_group.log_group.name}"
-  destination_arn = "${var.logger}"
+#   name            = "papertrail_forwarder"
+#   log_group_name  = "${aws_cloudwatch_log_group.log_group.name}"
+#   destination_arn = "${var.logger}"
 
-  # Forward all log messages:
-  filter_pattern = ""
-}
+#   # Forward all log messages:
+#   filter_pattern = ""
+# }
 
 # This is the "execution" role that is used to run this function:
 resource "aws_iam_role" "lambda_exec" {

--- a/shared/lambda_function/main.tf
+++ b/shared/lambda_function/main.tf
@@ -15,6 +15,11 @@ variable "config_vars" {
   default     = {}
 }
 
+variable "handler" {
+  description = "The handler for this function."
+  default     = "main.handler"
+}
+
 locals {
   safe_name = "${replace(var.name, "-", "_")}"
 }
@@ -22,7 +27,7 @@ locals {
 # The lambda function and API gateway:
 resource "aws_lambda_function" "function" {
   function_name = "${var.name}"
-  handler       = "main.handler"
+  handler       = "${var.handler}"
 
   s3_bucket = "${aws_s3_bucket.deploy.id}"
   s3_key    = "${aws_s3_bucket_object.release.key}"


### PR DESCRIPTION
**Work in progress.** This pull request uses our [lambda-papertrail](https://github.com/dosomething/lambda-papertrail) function to forward logs for our new Terraform-provisioned Lambdas from CloudWatch to Papertrail. The first step is to provision the functions, then configure CI for deploys, and finally attach them to the appropriate log groups.