### PR TITLE
Add Lookerbot resources.

### DIFF
--- a/applications/lookerbot/main.tf
+++ b/applications/lookerbot/main.tf
@@ -1,0 +1,30 @@
+# This template builds an S3 bucket for a Lookerbot instance.
+#
+# See https://github.com/looker/lookerbot#amazon-s3
+#
+# Manual setup steps:
+#   - Finally, head to the S3 Bucket in AWS after provisioning, and go to the
+#     Permissions -> Public Access Settings screen. Check all the options.
+#
+# NOTE: We'll move more of these steps into Terraform over time!
+
+# Required variables:
+variable "name" {
+  description = "The application name."
+}
+
+module "iam_user" {
+  source = "../../shared/iam_app_user"
+  name = "${var.name}"
+}
+
+module "storage" {
+  source = "../../shared/s3_bucket"
+
+  name = "${var.name}"
+  user = "${module.iam_user.name}"
+}
+
+output "name" {
+  value = "${var.name}"
+}

--- a/applications/lookerbot/main.tf
+++ b/applications/lookerbot/main.tf
@@ -15,7 +15,7 @@ variable "name" {
 
 module "iam_user" {
   source = "../../shared/iam_app_user"
-  name = "${var.name}"
+  name   = "${var.name}"
 }
 
 module "storage" {

--- a/applications/lookerbot/main.tf
+++ b/applications/lookerbot/main.tf
@@ -3,10 +3,16 @@
 # See https://github.com/looker/lookerbot#amazon-s3
 #
 # Manual setup steps:
-#   - Finally, head to the S3 Bucket in AWS after provisioning, and go to the
-#     Permissions -> Public Access Settings screen. Check all the options.
+#   - Head to <https://git.io/fh9DS> and hit "Deploy to Heroku" to provision the
+#     app.
+#   - Set the required environment variables via Heroku's admin panel.
+#     <https://git.io/fh9Dy>
+#   - Set the `SLACKBOT_S3_BUCKET`, `AWS_ACCESS_KEY_ID` &
+#     `AWS_SECRET_ACCESS_KEY` environment variables from the resources we've
+#     provisioned in this module.
 #
-# NOTE: We'll move more of these steps into Terraform over time!
+# NOTE: If this ends up being how we want to host & manage Lookerbot, we'll move
+# more of these steps into Terraform over time!
 
 # Required variables:
 variable "name" {

--- a/quasar/main.tf
+++ b/quasar/main.tf
@@ -1,3 +1,11 @@
+# Our Slack Lookerbot instance needs access to an S3 bucket to publish
+# visualizations.
+module "lookerbot" {
+  source = "../applications/lookerbot"
+
+  name = "lookerbot"
+}
+
 resource "aws_vpc" "vpc" {
   cidr_block = "10.255.0.0/16"
 


### PR DESCRIPTION
These changes declare an S3 bucket for our [Slack Lookerbot](https://github.com/looker/lookerbot) deploy, so it can publish visualizations to S3 and share those in Slack.