### PR TITLE
Add support for API Gateways with named routes.

### DIFF
--- a/applications/graphql-lambda/main.tf
+++ b/applications/graphql-lambda/main.tf
@@ -80,7 +80,6 @@ module "gateway" {
   source = "../../components/api_gateway_proxy"
 
   name                = "${var.name}"
-  environment         = "${var.environment}"
   function_arn        = "${module.app.arn}"
   function_invoke_arn = "${module.app.invoke_arn}"
   domain              = "${var.domain}"

--- a/applications/hello-serverless/main.tf
+++ b/applications/hello-serverless/main.tf
@@ -14,7 +14,6 @@ module "gateway" {
   source = "../../components/api_gateway_proxy"
 
   name                = "hello-serverless"
-  environment         = "development"
   function_arn        = "${module.app.arn}"
   function_invoke_arn = "${module.app.invoke_arn}"
   domain              = "hello-serverless.dosomething.org"

--- a/components/api_gateway/README.md
+++ b/components/api_gateway/README.md
@@ -20,7 +20,8 @@ module "gateway" {
   # The root function (required) responds to `/` requests:
   root_function        = "${module.app.arn}"
   # root_method        = "ANY" (optional)
-  # root_authorization = "NONE" (optional)
+  # root_authorization = "NONE" (optional, set to 'CUSTOM' for custom authorizer)
+  # root_authorizer_id = "${module.authorizer.invoke_arn}" (optional, if 'CUSTOM')
 
   # Any other routes can be defined in this list, with each route
   # expressed as a map of { path, function, method, authorization }
@@ -29,7 +30,8 @@ module "gateway" {
       path            = "{proxy+}"
       function        = "${module.app.invoke_arn}"
       # method        = "ANY" (optional)
-      # authorization = "NONE" (optional)
+      # authorization = "NONE" (optional, set to 'CUSTOM' for custom authorizer)
+      # authorizer_id = "${module.authorizer.invoke_arn}" (optional, if 'CUSTOM')
     },
   ]
 }

--- a/components/api_gateway/README.md
+++ b/components/api_gateway/README.md
@@ -1,0 +1,58 @@
+# API Gateway
+
+This module creates an [API Gateway](https://aws.amazon.com/api-gateway/). It's used to expose Lambda functions over the internet. If you only have one Lambda function that responds to all requests, consider using the [`api_gateway_proxy`](https://github.com/DoSomething/infrastructure/blob/master/components/api_gateway_proxy/) module instead.
+
+For all options, see the [variables](https://github.com/DoSomething/infrastructure/blob/master/components/api_gateway/variables.tf) this module accepts & [outputs](https://github.com/DoSomething/infrastructure/blob/master/components/api_gateway/outputs.tf) it generates.
+
+> :wave: Check out the [Getting Started](https://github.com/DoSomething/infrastructure/blob/master/docs/serverless-guide.md) guide for a step-by-step walkthrough!
+
+### Usage
+
+```hcl
+module "gateway" {
+  source = "../components/api_gateway"
+
+  name                = "hello-serverless"
+  
+  # The functions this gateway interacts with:
+  functions           = ["${module.app.arn}"]
+
+  # The root function (required) responds to `/` requests:
+  root_function        = "${module.app.arn}"
+  # root_method        = "ANY" (optional)
+  # root_authorization = "NONE" (optional)
+
+  # Any other routes can be defined in this list, with each route
+  # expressed as a map of { path, function, method, authorization }
+  routes = [
+    {
+      path            = "{proxy+}"
+      function        = "${module.app.invoke_arn}"
+      # method        = "ANY" (optional)
+      # authorization = "NONE" (optional)
+    },
+  ]
+}
+```
+
+You can configure [a custom domain](https://github.com/DoSomething/infrastructure/blob/master/docs/serverless-guide.md#bonus-add-a-custom-domain) by setting the `domain` variable. This will automatically configure a SSL certificate for DoSomething.org subdomains. If using another base domain (say, `dosome.click`), you'll need to first [add that domain to ACM & validate ownership](https://docs.aws.amazon.com/acm/latest/userguide/gs-acm-request-public.html):
+
+```hcl
+module "gateway" {
+  source = "../components/api_gateway"
+
+  name                = "hello-serverless"
+  functions           = ["${module.app.arn}"]
+  root_function       = "${module.app.arn}"
+
+  routes = [
+    {
+      path            = "{proxy+}"
+      function        = "${module.app.invoke_arn}"
+    },
+  ]
+
+  # The custom domain for this gateway:
+  domain = "hello-serverless.dosomething.org"
+}
+```

--- a/components/api_gateway/main.tf
+++ b/components/api_gateway/main.tf
@@ -14,6 +14,7 @@ resource "aws_api_gateway_method" "proxy_root" {
   resource_id   = "${aws_api_gateway_rest_api.gateway.root_resource_id}"
   http_method   = "${var.root_method}"
   authorization = "${var.root_authorization}"
+  authorizer_id = "${var.root_authorizer_id}"
 }
 
 resource "aws_api_gateway_integration" "lambda_root" {
@@ -43,6 +44,7 @@ resource "aws_api_gateway_method" "method" {
   resource_id   = "${aws_api_gateway_resource.resource.*.id[count.index]}"
   http_method   = "${lookup(var.routes[count.index], "method", "ANY")}"
   authorization = "${lookup(var.routes[count.index], "authorization", "NONE")}"
+  authorizer_id = "${lookup(var.routes[count.index], "authorizer_id", "")}"
 }
 
 resource "aws_api_gateway_integration" "integration" {

--- a/components/api_gateway/main.tf
+++ b/components/api_gateway/main.tf
@@ -1,0 +1,109 @@
+locals {
+  # Hack! Check if `var.domain` is a DS.org subdomain. <https://stackoverflow.com/a/47243622/811624>
+  is_dosomething_domain = "${replace(var.domain, ".dosomething.org", "") != var.domain}"
+}
+
+resource "aws_api_gateway_rest_api" "gateway" {
+  name        = "${var.name}"
+  description = "Managed with Terraform."
+}
+
+# Configure the root resource method & integration:
+resource "aws_api_gateway_method" "proxy_root" {
+  rest_api_id   = "${aws_api_gateway_rest_api.gateway.id}"
+  resource_id   = "${aws_api_gateway_rest_api.gateway.root_resource_id}"
+  http_method   = "${var.root_method}"
+  authorization = "${var.root_authorization}"
+}
+
+resource "aws_api_gateway_integration" "lambda_root" {
+  rest_api_id = "${aws_api_gateway_rest_api.gateway.id}"
+  resource_id = "${aws_api_gateway_method.proxy_root.resource_id}"
+  http_method = "${aws_api_gateway_method.proxy_root.http_method}"
+
+  # Lambda functions can only be invoked via POST.
+  integration_http_method = "POST"
+  type                    = "AWS_PROXY"
+  uri                     = "${var.root_function}"
+}
+
+# Configure any other routes, specified in the `routes` variable.
+resource "aws_api_gateway_resource" "resource" {
+  count = "${length(var.routes)}"
+
+  rest_api_id = "${aws_api_gateway_rest_api.gateway.id}"
+  parent_id   = "${aws_api_gateway_rest_api.gateway.root_resource_id}"
+  path_part   = "${lookup(var.routes[count.index], "path")}"
+}
+
+resource "aws_api_gateway_method" "method" {
+  count = "${length(var.routes)}"
+
+  rest_api_id   = "${aws_api_gateway_rest_api.gateway.id}"
+  resource_id   = "${aws_api_gateway_resource.resource.*.id[count.index]}"
+  http_method   = "${lookup(var.routes[count.index], "method", "ANY")}"
+  authorization = "${lookup(var.routes[count.index], "authorization", "NONE")}"
+}
+
+resource "aws_api_gateway_integration" "integration" {
+  count = "${length(var.routes)}"
+
+  rest_api_id = "${aws_api_gateway_rest_api.gateway.id}"
+  resource_id = "${aws_api_gateway_method.method.*.resource_id[count.index]}"
+  http_method = "${aws_api_gateway_method.method.*.http_method[count.index]}"
+
+  # Lambda functions can only be invoked via POST.
+  integration_http_method = "POST"
+  type                    = "AWS_PROXY"
+  uri                     = "${lookup(var.routes[count.index], "function")}"
+}
+
+resource "aws_api_gateway_deployment" "deployment" {
+  # Since this resource implicitly depends on all of the routes
+  # being configured, we'll set a explicit dependency here.
+  depends_on = [
+    "aws_api_gateway_integration.lambda_root",
+    "aws_api_gateway_integration.integration",
+  ]
+
+  rest_api_id = "${aws_api_gateway_rest_api.gateway.id}"
+  stage_name  = "default"
+}
+
+resource "aws_lambda_permission" "gateway_permission" {
+  count = "${length(var.functions)}"
+
+  statement_id  = "AllowAPIGatewayInvoke"
+  action        = "lambda:InvokeFunction"
+  function_name = "${var.functions[count.index]}"
+  principal     = "apigateway.amazonaws.com"
+
+  # The /*/* portion grants access from any HTTP method on any resource.
+  source_arn = "${aws_api_gateway_deployment.deployment.execution_arn}/*/*"
+}
+
+# Custom domain (optional):
+data "aws_acm_certificate" "certificate" {
+  count = "${var.domain == "" ? 0 : 1}"
+
+  # If this is a *.dosomething.org subdomain, use our wildcard ACM certificate.
+  # Otherwise, find a certificate for the provided domain (manually provisioned).
+  domain = "${local.is_dosomething_domain ? "*.dosomething.org" : var.domain}"
+
+  statuses = ["ISSUED"]
+}
+
+resource "aws_api_gateway_domain_name" "domain" {
+  count = "${var.domain == "" ? 0 : 1}"
+
+  certificate_arn = "${data.aws_acm_certificate.certificate.arn}"
+  domain_name     = "${var.domain}"
+}
+
+resource "aws_api_gateway_base_path_mapping" "mapping" {
+  count = "${var.domain == "" ? 0 : 1}"
+
+  api_id      = "${aws_api_gateway_rest_api.gateway.id}"
+  stage_name  = "${aws_api_gateway_deployment.deployment.stage_name}"
+  domain_name = "${aws_api_gateway_domain_name.domain.domain_name}"
+}

--- a/components/api_gateway/outputs.tf
+++ b/components/api_gateway/outputs.tf
@@ -1,0 +1,4 @@
+output "base_url" {
+  description = "The URL that this API Gateway is accessible at."
+  value       = "${var.domain == "" ? aws_api_gateway_deployment.deployment.invoke_url : "https://${var.domain}"}"
+}

--- a/components/api_gateway/variables.tf
+++ b/components/api_gateway/variables.tf
@@ -1,0 +1,40 @@
+# Required variables:
+variable "name" {
+  description = "The application name."
+}
+
+variable "functions" {
+  description = "The functions that this gateway is allowed to invoke."
+  type        = "list"
+}
+
+# The root route:
+variable "root_function" {
+  description = "The root route's function handler."
+}
+
+variable "root_method" {
+  description = "The root route's HTTP method."
+  default     = "ANY"
+}
+
+variable "root_authorization" {
+  description = "The root route's authorization type."
+  default     = "NONE"
+}
+
+# Additional routes:
+variable "routes" {
+  description = "A list of routes this gateway can respond to."
+
+  default = []
+}
+
+# Optional custom domain support:
+variable "domain" {
+  description = "The domain this application will be accessible at, e.g. lambda.dosomething.org"
+
+  # If omitted, we will just not attach a custom domain to this app. By default,
+  # you can access a Lambda function at a URL returned in the `base_url` output.
+  default = ""
+}

--- a/components/api_gateway/variables.tf
+++ b/components/api_gateway/variables.tf
@@ -23,6 +23,11 @@ variable "root_authorization" {
   default     = "NONE"
 }
 
+variable "root_authorizer_id" {
+  description = "If 'var.root_authorization' is 'CUSTOM', the Lambda to authorize with."
+  default     = ""
+}
+
 # Additional routes:
 variable "routes" {
   description = "A list of routes this gateway can respond to."

--- a/components/api_gateway_proxy/README.md
+++ b/components/api_gateway_proxy/README.md
@@ -1,6 +1,6 @@
 # API Gateway (Proxy)
 
-This module creates an [API Gateway](https://aws.amazon.com/api-gateway/). It's used to expose Lambda functions over the internet. At the moment, this module only supports using API Gateway as a "proxy" (so all requests to the given domain are forwarded to a single Lambda function, which handles routing internally).
+This module creates an [API Gateway](https://aws.amazon.com/api-gateway/). It's used to expose Lambda functions over the internet. If you want to use this gateway with multiple Lambda functions, use the [`api_gateway`](https://github.com/DoSomething/infrastructure/blob/master/components/api_gateway/) module instead.
 
 For all options, see the [variables](https://github.com/DoSomething/infrastructure/blob/master/components/api_gateway_proxy/variables.tf) this module accepts & [outputs](https://github.com/DoSomething/infrastructure/blob/master/components/api_gateway_proxy/outputs.tf) it generates.
 
@@ -13,7 +13,6 @@ module "gateway" {
   source = "../components/api_gateway_proxy"
 
   name                = "hello-serverless"
-  environment         = "development"
   function_arn        = "${module.app.arn}"
   function_invoke_arn = "${module.app.invoke_arn}"
 }

--- a/components/api_gateway_proxy/main.tf
+++ b/components/api_gateway_proxy/main.tf
@@ -1,99 +1,16 @@
-locals {
-  # Hack! Check if `var.domain` is a DS.org subdomain. <https://stackoverflow.com/a/47243622/811624>
-  is_dosomething_domain = "${replace(var.domain, ".dosomething.org", "") != var.domain}"
-}
+module "api_gateway" {
+  source = "../api_gateway"
 
-resource "aws_api_gateway_rest_api" "gateway" {
-  name        = "${var.name}"
-  description = "Managed with Terraform."
-}
+  name      = "${var.name}"
+  functions = ["${var.function_arn}"]
+  domain    = "${var.domain}"
 
-# We need separate proxies for the "root" path '/' and everything else '/*'
-# because reasons. Frustrating, but luckily we can abstract this away.
-resource "aws_api_gateway_method" "proxy_root" {
-  rest_api_id   = "${aws_api_gateway_rest_api.gateway.id}"
-  resource_id   = "${aws_api_gateway_rest_api.gateway.root_resource_id}"
-  http_method   = "ANY"
-  authorization = "NONE"
-}
+  root_function = "${var.function_invoke_arn}"
 
-resource "aws_api_gateway_integration" "lambda_root" {
-  rest_api_id = "${aws_api_gateway_rest_api.gateway.id}"
-  resource_id = "${aws_api_gateway_method.proxy_root.resource_id}"
-  http_method = "${aws_api_gateway_method.proxy_root.http_method}"
-
-  # Lambda functions can only be invoked via POST.
-  integration_http_method = "POST"
-  type                    = "AWS_PROXY"
-  uri                     = "${var.function_invoke_arn}"
-}
-
-resource "aws_api_gateway_resource" "proxy" {
-  rest_api_id = "${aws_api_gateway_rest_api.gateway.id}"
-  parent_id   = "${aws_api_gateway_rest_api.gateway.root_resource_id}"
-  path_part   = "{proxy+}"
-}
-
-resource "aws_api_gateway_method" "proxy" {
-  rest_api_id   = "${aws_api_gateway_rest_api.gateway.id}"
-  resource_id   = "${aws_api_gateway_resource.proxy.id}"
-  http_method   = "ANY"
-  authorization = "NONE"
-}
-
-resource "aws_api_gateway_integration" "lambda" {
-  rest_api_id = "${aws_api_gateway_rest_api.gateway.id}"
-  resource_id = "${aws_api_gateway_method.proxy.resource_id}"
-  http_method = "${aws_api_gateway_method.proxy.http_method}"
-
-  # Lambda functions can only be invoked via POST.
-  integration_http_method = "POST"
-  type                    = "AWS_PROXY"
-  uri                     = "${var.function_invoke_arn}"
-}
-
-resource "aws_api_gateway_deployment" "deployment" {
-  depends_on = [
-    "aws_api_gateway_integration.lambda",
-    "aws_api_gateway_integration.lambda_root",
+  routes = [
+    {
+      path     = "{proxy+}"
+      function = "${var.function_invoke_arn}"
+    },
   ]
-
-  rest_api_id = "${aws_api_gateway_rest_api.gateway.id}"
-  stage_name  = "${var.environment}"
-}
-
-resource "aws_lambda_permission" "gateway_permission" {
-  statement_id  = "AllowAPIGatewayInvoke"
-  action        = "lambda:InvokeFunction"
-  function_name = "${var.function_arn}"
-  principal     = "apigateway.amazonaws.com"
-
-  # The /*/* portion grants access from any HTTP method on any resource.
-  source_arn = "${aws_api_gateway_deployment.deployment.execution_arn}/*/*"
-}
-
-# Custom domain (optional):
-data "aws_acm_certificate" "certificate" {
-  count = "${var.domain == "" ? 0 : 1}"
-
-  # If this is a *.dosomething.org subdomain, use our wildcard ACM certificate.
-  # Otherwise, find a certificate for the provided domain (manually provisioned).
-  domain = "${local.is_dosomething_domain ? "*.dosomething.org" : var.domain}"
-
-  statuses = ["ISSUED"]
-}
-
-resource "aws_api_gateway_domain_name" "domain" {
-  count = "${var.domain == "" ? 0 : 1}"
-
-  certificate_arn = "${data.aws_acm_certificate.certificate.arn}"
-  domain_name     = "${var.domain}"
-}
-
-resource "aws_api_gateway_base_path_mapping" "mapping" {
-  count = "${var.domain == "" ? 0 : 1}"
-
-  api_id      = "${aws_api_gateway_rest_api.gateway.id}"
-  stage_name  = "${aws_api_gateway_deployment.deployment.stage_name}"
-  domain_name = "${aws_api_gateway_domain_name.domain.domain_name}"
 }

--- a/components/api_gateway_proxy/outputs.tf
+++ b/components/api_gateway_proxy/outputs.tf
@@ -1,4 +1,4 @@
 output "base_url" {
   description = "The URL that this API Gateway is accessible at."
-  value       = "${var.domain == "" ? aws_api_gateway_deployment.deployment.invoke_url : "https://${var.domain}"}"
+  value       = "${module.api_gateway.base_url}"
 }

--- a/components/api_gateway_proxy/variables.tf
+++ b/components/api_gateway_proxy/variables.tf
@@ -1,8 +1,4 @@
 # Required variables:
-variable "environment" {
-  description = "The environment for this application: development, qa, or production."
-}
-
 variable "name" {
   description = "The application name."
 }

--- a/quasar/main.tf
+++ b/quasar/main.tf
@@ -363,4 +363,7 @@ resource "aws_db_instance" "quasar" {
   copy_tags_to_snapshot  = true
   monitoring_interval    = "10"
   publicly_accessible    = true
+
+  # TEMPORARY: from @sheyd's testing over the weekend.
+  iops = 10000
 }


### PR DESCRIPTION
The last bit of cleanup for #129! This pull request adds support for using API Gateway with "named" routes pointing to different Lambdas (rather than only as a proxy). I've kept the existing `api_gateway_proxy` module as a "shortcut" for cases where it makes sense.

This pull request also removes the `var.environment` argument from each of these API Gateway modules, and instead names the (single) stage as `default`. (Rather than using stages, we keep development & QA applications in their own gateways for isolation & independent testing).

**Module documentation:** [API Gateway](https://github.com/DoSomething/infrastructure/tree/api-gateway-nonproxy/components/api_gateway), [API Gateway (Proxy)](https://github.com/DoSomething/infrastructure/tree/api-gateway-nonproxy/components/api_gateway_proxy)