### PR TITLE
Swap GraphQL Development & QA to the new Lambda backend.

### DIFF
--- a/dosomething-dev/main.tf
+++ b/dosomething-dev/main.tf
@@ -53,7 +53,7 @@ module "graphql_lambda" {
 
   environment = "development"
   name        = "dosomething-graphql-dev"
-  domain      = "graphql-lambda-dev.dosomething.org"
+  domain      = "graphql-dev.dosomething.org"
   logger      = "${module.papertrail.arn}"
 }
 

--- a/dosomething-qa/main.tf
+++ b/dosomething-qa/main.tf
@@ -49,7 +49,7 @@ module "graphql_lambda" {
 
   environment = "qa"
   name        = "dosomething-graphql-qa"
-  domain      = "graphql-lambda-qa.dosomething.org"
+  domain      = "graphql-qa.dosomething.org"
   logger      = "${module.papertrail.arn}"
 }
 


### PR DESCRIPTION
This pull request (should, we'll see) attach `graphql-dev.dosomething.org` and `graphql-qa.dosomething.org` to the appropriate API Gateways (and then once that's all provisioned behind the scenes, we can swap the DNS target for those domains for a zero-downtime switch).

Once these are swapped, we should run through some testing with applications that rely on GraphQL queries to see if there are any bugs that crop up. If all looks good, we can follow the same approach to swap production as well! 🚀 