### PR TITLE
Add base domain for Footlocker Internal.

### DIFF
--- a/longshot/main.tf
+++ b/longshot/main.tf
@@ -50,7 +50,7 @@ module "longshot-footlocker-internal" {
 
 # Attach base domain for FLScholarship.com as well.
 # TODO: Is there a better way to handle ANAMEs?
-resource "heroku_domain" "domain" {
+resource "heroku_domain" "flscholarship_base_domain" {
   app      = "${module.longshot-footlocker-internal.name}"
   hostname = "flscholarship.com"
 }

--- a/longshot/main.tf
+++ b/longshot/main.tf
@@ -48,6 +48,13 @@ module "longshot-footlocker-internal" {
   with_newrelic          = false
 }
 
+# Attach base domain for FLScholarship.com as well.
+# TODO: Is there a better way to handle ANAMEs?
+resource "heroku_domain" "domain" {
+  app      = "${module.longshot-footlocker-internal.name}"
+  hostname = "flscholarship.com"
+}
+
 module "hrblock" {
   source = "../applications/longshot"
 


### PR DESCRIPTION
This pull request attaches the base `flscholarship.com` to the Heroku app, so that Heroku knows how to respond to requests that come in sans the `www.` subdomain. (If we configure more applications like this, we'll probably want to add multiple domain support to the `heroku_app` module).

Closes #138.