### PR TITLE
Prepare to swap GraphQL to the Lambda backend in production.

### DIFF
--- a/dosomething/main.tf
+++ b/dosomething/main.tf
@@ -53,7 +53,7 @@ module "graphql_lambda" {
 
   environment = "production"
   name        = "dosomething-graphql"
-  domain      = "graphql-lambda.dosomething.org"
+  domain      = "graphql.dosomething.org"
   logger      = "${module.papertrail.arn}"
 }
 


### PR DESCRIPTION
This pull request follows in #149's footsteps and attaches `graphql.dosomething.org` to our production Lambda so we can provision the ACM certificate & CloudFront distribution in advance of swapping real traffic over tomorrow. :v: