### PR TITLE
Removing provisioned IOPS used for testing, revert to gp2.

### DIFF
--- a/quasar/main.tf
+++ b/quasar/main.tf
@@ -363,7 +363,4 @@ resource "aws_db_instance" "quasar" {
   copy_tags_to_snapshot  = true
   monitoring_interval    = "10"
   publicly_accessible    = true
-
-  # TEMPORARY: from @sheyd's testing over the weekend.
-  iops = 10000
 }


### PR DESCRIPTION
This PR reverts our Quasar Prod storage from provisioned IOPS to gp2 which we tested as a potential fix for: https://www.pivotaltracker.com/story/show/163565944. 