### PR TITLE
Use 3 queue workers on Northstar production

### DIFF
--- a/applications/northstar/main.tf
+++ b/applications/northstar/main.tf
@@ -117,7 +117,7 @@ module "app" {
   ignore_web = "${var.environment == "production"}"
 
   # We don't run a queue process on development right now. @TODO: Should we?
-  queue_scale = "${var.environment == "development" ? 0 : 1}"
+  queue_scale = "${lookup(map("development", 0, "qa", 1, "production", 3), var.environment)}"
 
   with_redis = true
   redis_type = "${var.environment == "production" ? "premium-1" : "hobby-dev"}"


### PR DESCRIPTION
We were already using 0 queue workers on development and 1 on QA, this just increases the production queue workers from 1 to 3:

```
~ module.dosomething.module.northstar.module.app.heroku_formation.queue
    quantity:   "1" => "3"
```

Was also getting a bunch of fastly changes when `make plan` ran but @DFurnes suspects that could be due to using the read-only credentials.