### PR TITLE
Set 'X-Fastly-State-Code' header on responses.

### DIFF
--- a/dosomething-dev/fastly-frontend/main.tf
+++ b/dosomething-dev/fastly-frontend/main.tf
@@ -142,6 +142,12 @@ resource "fastly_service_v1" "frontend-dev" {
   }
 
   snippet {
+    name    = "GeoIP - Set State Header"
+    type    = "deliver"
+    content = "${file("${path.root}/shared/state_deliver.vcl")}"
+  }
+
+  snippet {
     name    = "GDPR - Redirects Table"
     type    = "init"
     content = "${file("${path.root}/shared/gdpr_init.vcl")}"

--- a/dosomething-qa/fastly-frontend/main.tf
+++ b/dosomething-qa/fastly-frontend/main.tf
@@ -172,6 +172,12 @@ resource "fastly_service_v1" "frontend-qa" {
   }
 
   snippet {
+    name    = "GeoIP - Set State Header"
+    type    = "deliver"
+    content = "${file("${path.root}/shared/state_deliver.vcl")}"
+  }
+
+  snippet {
     name    = "Shared - Set X-Origin-Name Header"
     type    = "fetch"
     content = "${file("${path.root}/shared/origin_name.vcl")}"

--- a/dosomething/fastly-frontend/main.tf
+++ b/dosomething/fastly-frontend/main.tf
@@ -160,6 +160,12 @@ resource "fastly_service_v1" "frontend" {
   }
 
   snippet {
+    name    = "GeoIP - Set State Header"
+    type    = "deliver"
+    content = "${file("${path.root}/shared/state_deliver.vcl")}"
+  }
+
+  snippet {
     name    = "Shared - Set X-Origin-Name Header"
     type    = "fetch"
     content = "${file("${path.root}/shared/origin_name.vcl")}"

--- a/shared/state_deliver.vcl
+++ b/shared/state_deliver.vcl
@@ -1,0 +1,3 @@
+# Return state code (in the US) on responses so that
+# we can make use of this in client-side code.
+set resp.http.X-Fastly-State-Code = client.geo.region;


### PR DESCRIPTION
For Prom 👑 we want to start collecting state information on posts (so we can see _roughly_ where a story was submitted from). To do so, we'll use [Fastly's geolocation features](https://docs.fastly.com/vcl/geolocation/) to set a `X-Fastly-State-Code` header that the app can read!

Demonstrated in [this Fastly fiddle](https://fiddle.fastlydemo.net/fiddle/f038b78e).