### PR TITLE
Set X-Fastly-Region-Code header on both request and response.

### DIFF
--- a/dosomething-dev/fastly-frontend/main.tf
+++ b/dosomething-dev/fastly-frontend/main.tf
@@ -90,7 +90,7 @@ resource "fastly_service_v1" "frontend-dev" {
     name        = "Region Code"
     type        = "request"
     action      = "set"
-    source      = "geoip.region"
+    source      = "client.geo.region"
     destination = "http.X-Fastly-Region-Code"
   }
 
@@ -98,7 +98,7 @@ resource "fastly_service_v1" "frontend-dev" {
     name        = "Region Code (Debug)"
     type        = "response"
     action      = "set"
-    source      = "geoip.region"
+    source      = "client.geo.region"
     destination = "http.X-Fastly-Region-Code"
   }
 

--- a/dosomething-dev/fastly-frontend/main.tf
+++ b/dosomething-dev/fastly-frontend/main.tf
@@ -86,6 +86,22 @@ resource "fastly_service_v1" "frontend-dev" {
     destination = "http.X-Fastly-Country-Code"
   }
 
+  header {
+    name        = "Region Code"
+    type        = "request"
+    action      = "set"
+    source      = "geoip.region"
+    destination = "http.X-Fastly-Region-Code"
+  }
+
+  header {
+    name        = "Region Code (Debug)"
+    type        = "response"
+    action      = "set"
+    source      = "geoip.region"
+    destination = "http.X-Fastly-Region-Code"
+  }
+
   request_setting {
     name      = "Force SSL"
     force_ssl = true
@@ -139,12 +155,6 @@ resource "fastly_service_v1" "frontend-dev" {
     name    = "ProjectPages - Handle Redirect"
     type    = "error"
     content = "${file("${path.module}/legacy_redirects_error.vcl")}"
-  }
-
-  snippet {
-    name    = "GeoIP - Set State Header"
-    type    = "deliver"
-    content = "${file("${path.root}/shared/state_deliver.vcl")}"
   }
 
   snippet {

--- a/dosomething-qa/fastly-frontend/main.tf
+++ b/dosomething-qa/fastly-frontend/main.tf
@@ -108,7 +108,7 @@ resource "fastly_service_v1" "frontend-qa" {
     name        = "Region Code"
     type        = "request"
     action      = "set"
-    source      = "geoip.region"
+    source      = "client.geo.region"
     destination = "http.X-Fastly-Region-Code"
   }
 
@@ -116,7 +116,7 @@ resource "fastly_service_v1" "frontend-qa" {
     name        = "Region Code (Debug)"
     type        = "response"
     action      = "set"
-    source      = "geoip.region"
+    source      = "client.geo.region"
     destination = "http.X-Fastly-Region-Code"
   }
 

--- a/dosomething-qa/fastly-frontend/main.tf
+++ b/dosomething-qa/fastly-frontend/main.tf
@@ -104,6 +104,22 @@ resource "fastly_service_v1" "frontend-qa" {
     destination = "http.X-Fastly-Country-Code"
   }
 
+  header {
+    name        = "Region Code"
+    type        = "request"
+    action      = "set"
+    source      = "geoip.region"
+    destination = "http.X-Fastly-Region-Code"
+  }
+
+  header {
+    name        = "Region Code (Debug)"
+    type        = "response"
+    action      = "set"
+    source      = "geoip.region"
+    destination = "http.X-Fastly-Region-Code"
+  }
+
   request_setting {
     name      = "Force SSL"
     force_ssl = true
@@ -169,12 +185,6 @@ resource "fastly_service_v1" "frontend-qa" {
     name    = "GDPR - Handle Redirect"
     type    = "error"
     content = "${file("${path.root}/shared/gdpr_error.vcl")}"
-  }
-
-  snippet {
-    name    = "GeoIP - Set State Header"
-    type    = "deliver"
-    content = "${file("${path.root}/shared/state_deliver.vcl")}"
   }
 
   snippet {

--- a/dosomething/fastly-frontend/main.tf
+++ b/dosomething/fastly-frontend/main.tf
@@ -96,7 +96,7 @@ resource "fastly_service_v1" "frontend" {
     name        = "Region Code"
     type        = "request"
     action      = "set"
-    source      = "geoip.region"
+    source      = "client.geo.region"
     destination = "http.X-Fastly-Region-Code"
   }
 
@@ -104,7 +104,7 @@ resource "fastly_service_v1" "frontend" {
     name        = "Region Code (Debug)"
     type        = "response"
     action      = "set"
-    source      = "geoip.region"
+    source      = "client.geo.region"
     destination = "http.X-Fastly-Region-Code"
   }
 

--- a/dosomething/fastly-frontend/main.tf
+++ b/dosomething/fastly-frontend/main.tf
@@ -92,6 +92,22 @@ resource "fastly_service_v1" "frontend" {
     destination = "http.X-Fastly-Country-Code"
   }
 
+  header {
+    name        = "Region Code"
+    type        = "request"
+    action      = "set"
+    source      = "geoip.region"
+    destination = "http.X-Fastly-Region-Code"
+  }
+
+  header {
+    name        = "Region Code (Debug)"
+    type        = "response"
+    action      = "set"
+    source      = "geoip.region"
+    destination = "http.X-Fastly-Region-Code"
+  }
+
   request_setting {
     name      = "Force SSL"
     force_ssl = true
@@ -157,12 +173,6 @@ resource "fastly_service_v1" "frontend" {
     name    = "GDPR - Handle Redirect"
     type    = "error"
     content = "${file("${path.root}/shared/gdpr_error.vcl")}"
-  }
-
-  snippet {
-    name    = "GeoIP - Set State Header"
-    type    = "deliver"
-    content = "${file("${path.root}/shared/state_deliver.vcl")}"
   }
 
   snippet {

--- a/shared/state_deliver.vcl
+++ b/shared/state_deliver.vcl
@@ -1,3 +1,0 @@
-# Return state code (in the US) on responses so that
-# we can make use of this in client-side code.
-set resp.http.X-Fastly-State-Code = client.geo.region;


### PR DESCRIPTION
Two updates to this functionality:

💬 I'd assumed we could read this from the HTML response headers in JavaScript, but it [turns out that's not the case](https://github.com/DoSomething/phoenix-next/pull/1266). This pull request updates our front-end Fastly property to set the `X-Fastly-Region-Code` header on _both_ incoming requests & outgoing responses.

📃 I'd forgotten that we could just set this using the `header` block on the [fastly_service_v1](https://www.terraform.io/docs/providers/fastly/r/service_v1.html) resource, instead of having to write up a custom VCL snippet. Way simpler!