### PR TITLE
Use 'dev.dosomething.org' for Phoenix development, and 'preview.dosomething.org' for Phoenix preview.

### DIFF
--- a/dosomething-dev/fastly-backend/main.tf
+++ b/dosomething-dev/fastly-backend/main.tf
@@ -22,10 +22,6 @@ resource "fastly_service_v1" "backends-dev" {
   }
 
   domain {
-    name = "${var.phoenix_domain}"
-  }
-
-  domain {
     name = "${var.rogue_domain}"
   }
 
@@ -39,18 +35,6 @@ resource "fastly_service_v1" "backends-dev" {
     type      = "RESPONSE"
     name      = "response-northstar-dev"
     statement = "req.http.host == \"${var.northstar_domain}\""
-  }
-
-  condition {
-    type      = "REQUEST"
-    name      = "backend-phoenix-dev"
-    statement = "req.http.host == \"${var.phoenix_domain}\""
-  }
-
-  condition {
-    type      = "RESPONSE"
-    name      = "response-phoenix-dev"
-    statement = "req.http.host == \"${var.phoenix_domain}\""
   }
 
   condition {
@@ -87,15 +71,6 @@ resource "fastly_service_v1" "backends-dev" {
     address           = "${var.northstar_backend}"
     name              = "${var.northstar_name}"
     request_condition = "backend-northstar-dev"
-    shield            = "iad-va-us"
-    auto_loadbalance  = false
-    port              = 443
-  }
-
-  backend {
-    address           = "${var.phoenix_backend}"
-    name              = "${var.phoenix_name}"
-    request_condition = "backend-phoenix-dev"
     shield            = "iad-va-us"
     auto_loadbalance  = false
     port              = 443
@@ -194,14 +169,6 @@ resource "fastly_service_v1" "backends-dev" {
     port               = "${element(split(":", var.papertrail_destination), 1)}"
     format             = "%t '%r' status=%>s bytes=%b microseconds=%D"
     response_condition = "response-northstar-dev"
-  }
-
-  papertrail {
-    name               = "phoenix-dev"
-    address            = "${element(split(":", var.papertrail_destination), 0)}"
-    port               = "${element(split(":", var.papertrail_destination), 1)}"
-    format             = "${var.papertrail_log_format}"
-    response_condition = "response-phoenix-dev"
   }
 
   papertrail {

--- a/dosomething-dev/fastly-frontend/main.tf
+++ b/dosomething-dev/fastly-frontend/main.tf
@@ -8,7 +8,7 @@ resource "fastly_service_v1" "frontend-dev" {
   force_destroy = true
 
   domain {
-    name = "staging.dosomething.org"
+    name = "dev.dosomething.org"
   }
 
   condition {
@@ -29,8 +29,8 @@ resource "fastly_service_v1" "frontend-dev" {
     address           = "${var.ashes_backend}"
     name              = "ashes-staging"
     request_condition = "backend-ashes-dev"
-    ssl_cert_hostname = "staging.dosomething.org"
-    ssl_sni_hostname  = "staging.dosomething.org"
+    ssl_cert_hostname = "dev.dosomething.org"
+    ssl_sni_hostname  = "dev.dosomething.org"
     auto_loadbalance  = false
     use_ssl           = true
     port              = 443

--- a/dosomething-dev/main.tf
+++ b/dosomething-dev/main.tf
@@ -57,7 +57,7 @@ module "phoenix" {
 
   environment            = "development"
   name                   = "dosomething-phoenix-dev"
-  domain                 = "www-dev.dosomething.org"       # TODO: Just 'dev.dosomething.org'?
+  domain                 = "dev.dosomething.org"
   pipeline               = "${var.phoenix_pipeline}"
   papertrail_destination = "${var.papertrail_destination}"
 }

--- a/dosomething/main.tf
+++ b/dosomething/main.tf
@@ -67,8 +67,8 @@ module "phoenix_preview" {
 
   environment            = "production"
   name                   = "dosomething-phoenix-preview"
-  domain                 = "www-preview.dosomething.org"   # TODO: Just preview.dosomething.org!
   web_size               = "Hobby"                         # TODO: Should this be Standard-1X?
+  domain                 = "preview.dosomething.org"
   pipeline               = "${var.phoenix_pipeline}"
   papertrail_destination = "${var.papertrail_destination}"
 

--- a/dosomething/main.tf
+++ b/dosomething/main.tf
@@ -67,8 +67,8 @@ module "phoenix_preview" {
 
   environment            = "production"
   name                   = "dosomething-phoenix-preview"
-  web_size               = "Hobby"                         # TODO: Should this be Standard-1X?
   domain                 = "preview.dosomething.org"
+  web_size               = "Standard-1x"
   pipeline               = "${var.phoenix_pipeline}"
   papertrail_destination = "${var.papertrail_destination}"
 

--- a/redirects/main.tf
+++ b/redirects/main.tf
@@ -148,6 +148,10 @@ resource "fastly_service_v1" "redirects2" {
     name = "beta.dosomething.org"
   }
 
+  domain {
+    name = "www-dev.dosomething.org"
+  }
+
   # Note: Fastly requires at least one backend per service,
   # so our AWS HAProxy instance is included here.
   backend {

--- a/redirects/main.tf
+++ b/redirects/main.tf
@@ -152,6 +152,10 @@ resource "fastly_service_v1" "redirects2" {
     name = "www-dev.dosomething.org"
   }
 
+  domain {
+    name = "www-preview.dosomething.org"
+  }
+
   # Note: Fastly requires at least one backend per service,
   # so our AWS HAProxy instance is included here.
   backend {

--- a/redirects/redirects_table.vcl
+++ b/redirects/redirects_table.vcl
@@ -32,6 +32,7 @@ table redirects {
 
   # Phoenix:
   "phoenix-preview.dosomething.org": "https://www-preview.dosomething.org",
+  "www-dev.dosomething.org": "https://dev.dosomething.org",
 
   # Rogue:
   "rogue.dosomething.org": "https://activity.dosomething.org",

--- a/redirects/redirects_table.vcl
+++ b/redirects/redirects_table.vcl
@@ -31,7 +31,8 @@ table redirects {
   "profile.dosomething.org": "https://identity.dosomething.org",
 
   # Phoenix:
-  "phoenix-preview.dosomething.org": "https://www-preview.dosomething.org",
+  "phoenix-preview.dosomething.org": "https://preview.dosomething.org",
+  "www-preview.dosomething.org": "https://preview.dosomething.org",
   "www-dev.dosomething.org": "https://dev.dosomething.org",
 
   # Rogue:


### PR DESCRIPTION
We'd been running `staging.dosomething.org` through our Fastly frontend service for the development environment, but I think most people (myself included) were using `www-dev.dosomething.org` to test things out. This pull request updates this app to run through our frontend property via `dev.dosomething.org` for consistency.

We had originally used this domain for local Ashes development and instructed developers to set it to loopback to localhost on their `/etc/hosts` files. I'll drop a note in #announce-tech to make sure everyone has removed that entry once this is all in place.