### PR TITLE
WIP - Quasar QA Tuning for Large Queries 

### DIFF
--- a/quasar/main.tf
+++ b/quasar/main.tf
@@ -254,14 +254,22 @@ resource "aws_db_parameter_group" "quasar-qa" {
   # Recommended by PGTuner tool: https://pgtune.leopard.in.ua/#/
   # Amount of RAM available for joins/sort queries per connection.
   # Based on 50 connections.
+  # Prev Setting is 20971, changing to see if helps with large sorts
   parameter {
     name  = "work_mem"
-    value = "20971"
+    value = "64000"
   }
 
   # Recommended to only allow SSL connections from clients.
   parameter {
     name  = "rds.force_ssl"
+    value = "1"
+  }
+
+  # Based on https://amplitude.engineering/how-a-single-postgresql-config-change-improved-slow-query-performance-by-50x-85593b8991b0
+  # Attempting to set random_page_cost to 1 since we use gp2 SSD in RDS. This is a testing setting.
+  parameter {
+    name  = "random_page_cost"
     value = "1"
   }
 }


### PR DESCRIPTION
@blisteringherb is testing out some large query optimizations for our email funnel and found https://amplitude.engineering/how-a-single-postgresql-config-change-improved-slow-query-performance-by-50x-85593b8991b0 which recommended changing `random_page_cost`, and also the `work_mem` since the EXPLAIN statement seemed prefer using full table scans vs indexes that exist, and higher `work_mem` value will allow more memory allocations for sort/join queries. 