### PR TITLE
Updating log settings for slow queries

### DIFF
--- a/quasar/main.tf
+++ b/quasar/main.tf
@@ -264,6 +264,24 @@ resource "aws_db_parameter_group" "quasar-qa" {
     name  = "rds.force_ssl"
     value = "1"
   }
+
+  # Only log queries with a duration longer than this to get slow queries.
+  parameter {
+    name  = "log_min_duration_statement"
+    value = "1000"
+  }
+
+  # Log duration of queries.
+  parameter {
+    name  = "log_duration"
+    value = "on"
+  }
+
+  # Temporarily only log slow queries.
+  parameter {
+    name  = "log_statement"
+    value = "none"
+  }
 }
 
 resource "aws_db_parameter_group" "quasar-prod" {
@@ -312,6 +330,24 @@ resource "aws_db_parameter_group" "quasar-prod" {
   parameter {
     name  = "rds.force_ssl"
     value = "1"
+  }
+
+  # Only log queries with a duration longer than this to get slow queries.
+  parameter {
+    name  = "log_min_duration_statement"
+    value = "1000"
+  }
+
+  # Log duration of queries.
+  parameter {
+    name  = "log_duration"
+    value = "on"
+  }
+
+  # Temporarily only log slow queries.
+  parameter {
+    name  = "log_statement"
+    value = "none"
   }
 }
 


### PR DESCRIPTION
This adds log settings so that we're capturing slow queries. We may want to change `log_statement` soon after we gather our slow query info so that we're not missing log entries. This will update the following settings:
`log_min_duration_statement`
`log_statement`
`log_duration`

Note: This will remove the `random_page_cost` and `work_mem` settings we have set up in QA since those aren't committed to master yet. 