### PR TITLE
Disable Synchronous Query to Disk 

### DIFF
--- a/quasar/main.tf
+++ b/quasar/main.tf
@@ -271,10 +271,10 @@ resource "aws_db_parameter_group" "quasar-qa" {
     value = "1000"
   }
 
-  # Temporarily only log slow queries.
+  # Testing turning synchronization off to see if improves performance
   parameter {
-    name  = "log_statement"
-    value = "none"
+    name  = "synchronous_commit"
+    value = "off"
   }
 }
 

--- a/quasar/main.tf
+++ b/quasar/main.tf
@@ -277,11 +277,21 @@ resource "aws_db_parameter_group" "quasar-qa" {
     value = "none"
   }
 
+  parameter {
+    name  = "log_duration"
+    value = "0"
+  }
+
   # Testing turning synchronization off to see if improves performance
   parameter {
     name  = "synchronous_commit"
     value = "off"
   }
+
+  #   parameter {
+  #     name  = "random_page_cost"
+  #     value = "1"
+  #  }
 }
 
 resource "aws_db_parameter_group" "quasar-prod" {
@@ -342,6 +352,11 @@ resource "aws_db_parameter_group" "quasar-prod" {
   parameter {
     name  = "log_statement"
     value = "none"
+  }
+
+  parameter {
+    name  = "log_duration"
+    value = "0"
   }
 }
 

--- a/quasar/main.tf
+++ b/quasar/main.tf
@@ -271,6 +271,12 @@ resource "aws_db_parameter_group" "quasar-qa" {
     value = "1000"
   }
 
+  # Only log slow queries.
+  parameter {
+    name  = "log_statement"
+    value = "none"
+  }
+
   # Testing turning synchronization off to see if improves performance
   parameter {
     name  = "synchronous_commit"


### PR DESCRIPTION
Per Sean Hull's recommendation, we don't need to have each transaction committed to disk before they report back as successful, and with the tradeoff of potentially losing a small amount of data for a large performance boost. Testing out in QA first.