### PR TITLE
Add basic Chompy application template & generate API keys.

### DIFF
--- a/applications/chompy/main.tf
+++ b/applications/chompy/main.tf
@@ -10,6 +10,10 @@ variable "name" {
   description = "The application name."
 }
 
+resource "random_string" "importer_api_key" {
+  length = 32
+}
+
 # TODO: Use our 'heroku_app' module to configure more of this!
 resource "heroku_app" "app" {
   name   = "${var.name}"
@@ -20,7 +24,7 @@ resource "heroku_app" "app" {
   }
 
   config_vars = {
-    IMPORTER_API_KEY = "lalalala"
+    IMPORTER_API_KEY = "${random_string.importer_api_key.result}"
   }
 
   buildpacks = [

--- a/applications/chompy/main.tf
+++ b/applications/chompy/main.tf
@@ -1,0 +1,32 @@
+# This template builds a Rogue application instance.
+#
+# Manual setup steps:
+#  - TBD! Talk to Chloe and/or Dave! :)
+#
+# NOTE: We'll move more of these steps into Terraform over time!
+
+# Required variables:
+variable "name" {
+  description = "The application name."
+}
+
+# TODO: Use our 'heroku_app' module to configure more of this!
+resource "heroku_app" "app" {
+  name   = "${var.name}"
+  region = "us"
+
+  organization {
+    name = "dosomething"
+  }
+
+  config_vars = {
+    IMPORTER_API_KEY = "lalalala"
+  }
+
+  buildpacks = [
+    "heroku/nodejs",
+    "heroku/php",
+  ]
+
+  acm = true
+}

--- a/dosomething-qa/main.tf
+++ b/dosomething-qa/main.tf
@@ -4,6 +4,12 @@ variable "rogue_pipeline" {}
 variable "papertrail_destination" {}
 variable "papertrail_destination_fastly" {}
 
+module "chompy" {
+  source = "../applications/chompy"
+
+  name = "dosomething-chompy-qa"
+}
+
 module "fastly-frontend" {
   source = "fastly-frontend"
 

--- a/dosomething/main.tf
+++ b/dosomething/main.tf
@@ -4,6 +4,12 @@ variable "rogue_pipeline" {}
 variable "papertrail_destination" {}
 variable "papertrail_destination_fastly" {}
 
+module "chompy" {
+  source = "../applications/chompy"
+
+  name = "dosomething-chompy"
+}
+
 module "fastly-frontend" {
   source = "fastly-frontend"
 


### PR DESCRIPTION
This pull request adds a super bare-bones Chompy application template & sets the `IMPORTER_API_KEY` environment variable using a [`random_string`](https://www.terraform.io/docs/providers/random/r/string.html) resource. This allows us to safely generate a secure key. If we wanted to re-generate this later (say, if it leaked), we'd just run:

```
terraform taint -module=dosomething-qa.chompy random_string.importer_api_key
```

We were a little pressed for time, so we only set up the apps themselves (without bothering to hook up the domain, logging, database, S3 bucket, queue, yadda yadda). This is something we should totally revisit when we have time during a cleanup sprint later in the quarter! 