### PR TITLE
Add 'Vary' header to S3 responses that are missing it.

### DIFF
--- a/dosomething/fastly-frontend/main.tf
+++ b/dosomething/fastly-frontend/main.tf
@@ -111,7 +111,6 @@ resource "fastly_service_v1" "frontend" {
     action             = "set"
     destination        = "http.Vary"
     source             = "\"Origin, Access-Control-Request-Headers, Access-Control-Request-Method\""
-    ignore_if_set      = true
   }
 
   header {

--- a/dosomething/fastly-frontend/main.tf
+++ b/dosomething/fastly-frontend/main.tf
@@ -24,8 +24,8 @@ resource "fastly_service_v1" "frontend" {
   }
 
   condition {
-    type      = "RESPONSE"
-    name      = "response-assets"
+    type      = "CACHE"
+    name      = "cache-assets"
     statement = "req.http.host == \"${var.assets_domain}\""
   }
 
@@ -106,8 +106,8 @@ resource "fastly_service_v1" "frontend" {
   # expected 'Vary' if it isn't already set on the response.
   header {
     name               = "S3 Vary"
-    type               = "response"
-    response_condition = "response-assets"
+    type               = "cache"
+    response_condition = "cache-assets"
     action             = "set"
     destination        = "http.Vary"
     source             = "\"Origin, Access-Control-Request-Headers, Access-Control-Request-Method\""

--- a/dosomething/fastly-frontend/main.tf
+++ b/dosomething/fastly-frontend/main.tf
@@ -110,7 +110,7 @@ resource "fastly_service_v1" "frontend" {
     response_condition = "response-assets"
     action             = "set"
     destination        = "http.Vary"
-    source             = "Origin, Access-Control-Request-Headers, Access-Control-Request-Method"
+    source             = "\"Origin, Access-Control-Request-Headers, Access-Control-Request-Method\""
     ignore_if_set      = true
   }
 

--- a/dosomething/fastly-frontend/main.tf
+++ b/dosomething/fastly-frontend/main.tf
@@ -105,12 +105,12 @@ resource "fastly_service_v1" "frontend" {
   # means we may accidentally cache a CORS-less response for everyone. This rule adds the
   # expected 'Vary' if it isn't already set on the response.
   header {
-    name               = "S3 Vary"
-    type               = "cache"
-    response_condition = "cache-assets"
-    action             = "set"
-    destination        = "http.Vary"
-    source             = "\"Origin, Access-Control-Request-Headers, Access-Control-Request-Method\""
+    name            = "S3 Vary"
+    type            = "cache"
+    cache_condition = "cache-assets"
+    action          = "set"
+    destination     = "http.Vary"
+    source          = "\"Origin, Access-Control-Request-Headers, Access-Control-Request-Method\""
   }
 
   header {

--- a/dosomething/fastly-frontend/main.tf
+++ b/dosomething/fastly-frontend/main.tf
@@ -24,6 +24,12 @@ resource "fastly_service_v1" "frontend" {
   }
 
   condition {
+    type      = "RESPONSE"
+    name      = "response-assets"
+    statement = "req.http.host == \"${var.assets_domain}\""
+  }
+
+  condition {
     type = "REQUEST"
     name = "backend-ashes"
 
@@ -93,6 +99,19 @@ resource "fastly_service_v1" "frontend" {
       "text/plain",
       "text/xml",
     ]
+  }
+
+  # The S3 backend only returns a 'Vary' header if a request has a CORS header on it, which
+  # means we may accidentally cache a CORS-less response for everyone. This rule adds the
+  # expected 'Vary' if it isn't already set on the response.
+  header {
+    name               = "S3 Vary"
+    type               = "response"
+    response_condition = "response-assets"
+    action             = "set"
+    destination        = "http.Vary"
+    source             = "Origin, Access-Control-Request-Headers, Access-Control-Request-Method"
+    ignore_if_set      = true
   }
 
   header {


### PR DESCRIPTION
This pull request should fix a [rather frustrating oversight](https://forums.aws.amazon.com/message.jspa?messageID=804087) in S3's CORS support, where the `Vary` header is omitted for requests that don't have a CORS header (and therefore Fastly, CloudFront, or whoever will then just cache the CORS-less response for everyone).

Here's the plan for this change:

```
~ module.dosomething.module.fastly-frontend.fastly_service_v1.frontend
    condition.#:                            "3" => "4"
    condition.3035584417.name:              "" => "response-assets"
    condition.3035584417.priority:          "" => "10"
    condition.3035584417.statement:         "" => "req.http.host == "assets.dosomething.org""
    condition.3035584417.type:              "" => "RESPONSE"
    header.#:                               "4" => "5"
    header.3732783554.action:               "" => "set"
    header.3732783554.destination:          "" => "http.Vary"
    header.3732783554.ignore_if_set:        "" => "true"
    header.3732783554.name:                 "" => "S3 Vary"
    header.3732783554.priority:             "" => "100"
    header.3732783554.regex:                "" => "<computed>"
    header.3732783554.response_condition:   "" => "response-assets"
    header.3732783554.source:               "" => "Origin, Access-Control-Request-Headers, Access-Control-Request-Method"
    header.3732783554.substitution:         "" => "<computed>"
    header.3732783554.type:                 "" => "response"

Plan: 0 to add, 1 to change, 0 to destroy.
```

References [#165498230](https://www.pivotaltracker.com/story/show/165498230).