### PR TITLE
Add a 'force pass' rule for authenticated requests.

### DIFF
--- a/dosomething-dev/fastly-frontend/main.tf
+++ b/dosomething-dev/fastly-frontend/main.tf
@@ -44,9 +44,12 @@ resource "fastly_service_v1" "frontend-dev" {
   }
 
   condition {
-    type      = "REQUEST"
-    name      = "is-authenticated"
-    statement = "req.http.Cookie ~ \"laravel_session=\""
+    type = "REQUEST"
+    name = "is-authenticated"
+
+    # We want exclude logged-in users from Fastly caching (since their responses will 
+    # likely include user-specific content) but still cache static assets at the edge.
+    statement = "req.http.Cookie ~ \"laravel_session=\" && req.url !~ \"\\.(css|js|woff|otf|ttf|svg)(\\?.*)?$\""
   }
 
   request_setting {

--- a/dosomething-dev/fastly-frontend/main.tf
+++ b/dosomething-dev/fastly-frontend/main.tf
@@ -43,6 +43,18 @@ resource "fastly_service_v1" "frontend-dev" {
     port             = 443
   }
 
+  condition {
+    type      = "REQUEST"
+    name      = "is-authenticated"
+    statement = "req.http.Cookie ~ \"laravel_session=\""
+  }
+
+  request_setting {
+    name              = "pass-authenticated"
+    request_condition = "is-authenticated"
+    action            = "pass"
+  }
+
   gzip {
     name = "gzip"
 

--- a/dosomething-qa/fastly-frontend/main.tf
+++ b/dosomething-qa/fastly-frontend/main.tf
@@ -61,6 +61,21 @@ resource "fastly_service_v1" "frontend-qa" {
     port             = 443
   }
 
+  condition {
+    type = "REQUEST"
+    name = "is-authenticated"
+
+    # We want exclude logged-in users from Fastly caching (since their responses will 
+    # likely include user-specific content) but still cache static assets at the edge.
+    statement = "req.http.Cookie ~ \"laravel_session=\" && req.url !~ \"\\.(css|js|woff|otf|ttf|svg)(\\?.*)?$\""
+  }
+
+  request_setting {
+    name              = "pass-authenticated"
+    request_condition = "is-authenticated"
+    action            = "pass"
+  }
+
   gzip {
     name = "gzip"
 

--- a/dosomething/fastly-frontend/main.tf
+++ b/dosomething/fastly-frontend/main.tf
@@ -74,6 +74,21 @@ resource "fastly_service_v1" "frontend" {
     port             = 443
   }
 
+  condition {
+    type = "REQUEST"
+    name = "is-authenticated"
+
+    # We want exclude logged-in users from Fastly caching (since their responses will 
+    # likely include user-specific content) but still cache static assets at the edge.
+    statement = "req.http.Cookie ~ \"laravel_session=\" && req.url !~ \"\\.(css|js|woff|otf|ttf|svg)(\\?.*)?$\""
+  }
+
+  request_setting {
+    name              = "pass-authenticated"
+    request_condition = "is-authenticated"
+    action            = "pass"
+  }
+
   gzip {
     name = "gzip"
 


### PR DESCRIPTION
This pull request adds a "force pass" rule that tells Fastly to send along authenticated requests to the backend (so we can cache page markup in Fastly for anonymous folks, but not serve that same response to folks who are logged-in).

References DoSomething/phoenix-next#1395 and [#165515770](https://www.pivotaltracker.com/story/show/165515770).