### PR TITLE
Adding new PG11 parameter group to prepare for upgrade

### DIFF
--- a/quasar/main.tf
+++ b/quasar/main.tf
@@ -294,9 +294,147 @@ resource "aws_db_parameter_group" "quasar-qa" {
   #  }
 }
 
+resource "aws_db_parameter_group" "quasar-qa-pg11" {
+  name   = "quasar-qa-pg11"
+  family = "postgres11"
+
+  # Required for DMS CDC Replication:
+  # https://docs.aws.amazon.com/dms/latest/userguide/CHAP_Source.PostgreSQL.html#CHAP_Source.PostgreSQL.v10
+  parameter {
+    name         = "rds.logical_replication"
+    value        = "1"
+    apply_method = "pending-reboot"
+  }
+
+  # Required for DMS CDC Replication:
+  # https://docs.aws.amazon.com/dms/latest/userguide/CHAP_Source.PostgreSQL.html#CHAP_Source.PostgreSQL.v10
+  parameter {
+    name         = "max_logical_replication_workers"
+    value        = "500"
+    apply_method = "pending-reboot"
+  }
+
+  # Recommended by PGTuner tool: https://pgtune.leopard.in.ua/#/
+  # Sets effective RAM available to PG Query planner before using disk.
+  parameter {
+    name  = "effective_cache_size"
+    value = "24000000"
+  }
+
+  # Recommended by PGTuner tool: https://pgtune.leopard.in.ua/#/
+  # Amount of RAM available for cleanup tasks like vacuum, reindex, etc.
+  parameter {
+    name  = "maintenance_work_mem"
+    value = "2000000"
+  }
+
+  # Recommended by PGTuner tool: https://pgtune.leopard.in.ua/#/
+  # Amount of RAM available for joins/sort queries per connection.
+  # Based on 50 connections.
+  parameter {
+    name  = "work_mem"
+    value = "20971"
+  }
+
+  # Recommended to only allow SSL connections from clients.
+  parameter {
+    name  = "rds.force_ssl"
+    value = "1"
+  }
+
+  # Only log queries with a duration longer than this to get slow queries.
+  parameter {
+    name  = "log_min_duration_statement"
+    value = "1000"
+  }
+
+  # Only log slow queries.
+  parameter {
+    name  = "log_statement"
+    value = "none"
+  }
+
+  parameter {
+    name  = "log_duration"
+    value = "0"
+  }
+
+  # Testing turning synchronization off to see if improves performance
+  parameter {
+    name  = "synchronous_commit"
+    value = "off"
+  }
+}
+
 resource "aws_db_parameter_group" "quasar-prod" {
   name   = "quasar-prod"
   family = "postgres10"
+
+  # Required for DMS CDC Replication:
+  # https://docs.aws.amazon.com/dms/latest/userguide/CHAP_Source.PostgreSQL.html#CHAP_Source.PostgreSQL.v10
+  parameter {
+    name         = "rds.logical_replication"
+    value        = "1"
+    apply_method = "pending-reboot"
+  }
+
+  # Required for DMS CDC Replication:
+  # https://docs.aws.amazon.com/dms/latest/userguide/CHAP_Source.PostgreSQL.html#CHAP_Source.PostgreSQL.v10
+  parameter {
+    name         = "max_logical_replication_workers"
+    value        = "500"
+    apply_method = "pending-reboot"
+  }
+
+  # Recommended by PGTuner tool: https://pgtune.leopard.in.ua/#/
+  # Sets effective RAM available to PG Query planner before using disk.
+  parameter {
+    name  = "effective_cache_size"
+    value = "48000000"
+  }
+
+  # Recommended by PGTuner tool: https://pgtune.leopard.in.ua/#/
+  # Amount of RAM available for cleanup tasks like vacuum, reindex, etc.
+  parameter {
+    name  = "maintenance_work_mem"
+    value = "2000000"
+  }
+
+  # Updated to match Heroku Premium-5 config which we experienced
+  # as more performant when our data warehouse was hosted there.
+  # Amount of RAM available for joins/sort queries per connection.
+  parameter {
+    name  = "work_mem"
+    value = "120000"
+  }
+
+  # Recommended to only allow SSL connections from clients.
+  parameter {
+    name  = "rds.force_ssl"
+    value = "1"
+  }
+
+  # Only log queries with a duration longer than this to get slow queries.
+  parameter {
+    name  = "log_min_duration_statement"
+    value = "1000"
+  }
+
+  # Temporarily only log slow queries.
+  parameter {
+    name  = "log_statement"
+    value = "none"
+  }
+
+  parameter {
+    name  = "log_duration"
+    value = "0"
+  }
+}
+
+resource "aws_db_parameter_group" "quasar-prod-pg11" {
+  name   = "quasar-prod-pg11"
+  family = "postgres11"
 
   # Required for DMS CDC Replication:
   # https://docs.aws.amazon.com/dms/latest/userguide/CHAP_Source.PostgreSQL.html#CHAP_Source.PostgreSQL.v10
@@ -379,7 +517,7 @@ data "aws_ssm_parameter" "prod_password" {
 resource "aws_db_instance" "quasar-qa" {
   allocated_storage               = 1000
   engine                          = "postgres"
-  engine_version                  = "10.6"
+  engine_version                  = "11.1"
   instance_class                  = "db.m5.2xlarge"
   name                            = "quasar"
   username                        = "${data.aws_ssm_parameter.qa_username.value}"


### PR DESCRIPTION
This PR adds two new Postgres 11 parameter groups to prepare for our upgrade. We'll need to run a `make apply` to add these before running the upgrade on either QA or Prod, but there shouldn't be any impact to creating both of these together.

After this PR is approved I'll run this, and then put in a separate PR to upgrade QA to Postgres 11.