### PR TITLE
Updating settings to run QA PG11 update immediately

### DIFF
--- a/quasar/main.tf
+++ b/quasar/main.tf
@@ -523,7 +523,7 @@ resource "aws_db_instance" "quasar-qa" {
   name                            = "quasar"
   username                        = "${data.aws_ssm_parameter.qa_username.value}"
   password                        = "${data.aws_ssm_parameter.qa_password.value}"
-  parameter_group_name            = "${aws_db_parameter_group.quasar-qa.id}"
+  parameter_group_name            = "${aws_db_parameter_group.quasar-qa-pg11.id}"
   vpc_security_group_ids          = ["${aws_security_group.rds.id}"]
   deletion_protection             = true
   storage_encrypted               = true

--- a/quasar/main.tf
+++ b/quasar/main.tf
@@ -519,6 +519,7 @@ resource "aws_db_instance" "quasar-qa" {
   engine                          = "postgres"
   engine_version                  = "11.1"
   instance_class                  = "db.m5.2xlarge"
+  allow_major_version_upgrade     = true
   name                            = "quasar"
   username                        = "${data.aws_ssm_parameter.qa_username.value}"
   password                        = "${data.aws_ssm_parameter.qa_password.value}"
@@ -530,6 +531,7 @@ resource "aws_db_instance" "quasar-qa" {
   monitoring_interval             = "10"
   publicly_accessible             = true
   enabled_cloudwatch_logs_exports = ["postgresql"]
+  apply_immediately               = true
 }
 
 resource "aws_db_instance" "quasar" {

--- a/quasar/main.tf
+++ b/quasar/main.tf
@@ -531,7 +531,6 @@ resource "aws_db_instance" "quasar-qa" {
   monitoring_interval             = "10"
   publicly_accessible             = true
   enabled_cloudwatch_logs_exports = ["postgresql"]
-  apply_immediately               = true
 }
 
 resource "aws_db_instance" "quasar" {


### PR DESCRIPTION
This PR updates the settings for QA Quasar so that we can upgrade immediately to Postgres 11. Without this code I was running into the following error:

```
aws_db_instance.quasar-qa: Error modifying DB Instance quasar-qa: InvalidParameterCombination: The AllowMajorVersionUpgrade flag must be present when upgrading to a new major version.
```

This PR adds the `allow_major_version_upgrade` and `apply_immediately` flags for Quasar QA.