### PR TITLE
Swap backend to Terraform Enterprise.

### DIFF
--- a/README.md
+++ b/README.md
@@ -43,7 +43,7 @@ Next, **make a plan** to find out how it will affect the current state of the sy
 make plan
 ```
 
-Once you're satisfied with Terraform's plan, commit your work & make a pull request. After your pull request is reviewed, you can then **apply your change** to update the actual infrastructure. Terraform will make your changes, update the state in S3, and ensure nobody else makes any changes until you're done:
+Once you're satisfied with Terraform's plan, commit your work & make a pull request. After your pull request is reviewed, you can then **apply your change** to update the actual infrastructure. Terraform will make your changes, update the remote state, and ensure nobody else makes any changes until you're done:
 
 ```sh
 make apply

--- a/README.md
+++ b/README.md
@@ -10,17 +10,25 @@ Install [Terraform](https://www.terraform.io) 0.11.x, [Landscape](https://github
 brew install awscli terraform terraform_landscape
 ```
 
-Next, configure secrets (see the "Terraform credentials" secure note in Lastpass) & install dependencies:
+Create a [Terraform.io account](https://app.terraform.io/account/new) with your work email & ask for an invite to our organization in [#dev-infrastructure](https://dosomething.slack.com/messages/C03T8SDJJ/). Don't forget to [enable two-factor auth](https://www.terraform.io/docs/enterprise/users-teams-organizations/2fa.html)!  Then, [create a user API token](https://www.terraform.io/docs/enterprise/users-teams-organizations/users.html#api-tokens) and place it in your `~/.terraformrc` file, like so:
+
+```hcl
+credentials "app.terraform.io" {
+  token = "xxxxxx.atlasv1.zzzzzzzzzzzzz"
+}
+```
+
+Next, configure provider secrets (see the "Terraform credentials" secure note in Lastpass) & install dependencies:
 
 ```sh
 # Configure 'terraform' AWS profile:
 aws configure --profile terraform
 
-# Connect to S3 backend & install dependencies:
-make init
-
 # Configure other backends w/ secrets from Lastpass:
 vi terraform.tfvars
+
+# Connect to remote backend & install dependencies:
+make init
 ```
 
 ## Usage

--- a/README.md
+++ b/README.md
@@ -4,7 +4,7 @@ This is DoSomething.org's infrastructure as code, built using [Terraform](https:
 
 ## Installation
 
-Install [Terraform](https://www.terraform.io) 0.11.x, [Landscape](https://github.com/coinbase/terraform-landscape), and the [AWS CLI](https://aws.amazon.com/cli/). On macOS, this is easy with [Homebrew](https://brew.sh):
+Install [Terraform](https://www.terraform.io) 0.11.3, [Landscape](https://github.com/coinbase/terraform-landscape), and the [AWS CLI](https://aws.amazon.com/cli/). On macOS, this is easy with [Homebrew](https://brew.sh):
 
 ```sh
 brew install awscli terraform terraform_landscape

--- a/main.tf
+++ b/main.tf
@@ -20,17 +20,14 @@ variable "papertrail_destination_fastly" {}
 # ----------------------------------------------------
 
 # We store our Terraform state (what the whole system
-# currently looks like) in a private S3 bucket, and use
-# a DynamoDB table to "lock" the system so only one
-# person can make changes at a time.
+# currently looks like) in Terraform Enterprise.
 terraform {
-  backend "s3" {
-    bucket         = "dosomething-infrastructure-state"
-    dynamodb_table = "dosomething-infrastructure-locks"
-    key            = "terraform.tfstate"
-    region         = "us-east-1"
-    profile        = "terraform"
-    encrypt        = true
+  backend "remote" {
+    organization = "dosomething"
+
+    workspaces {
+      name = "infrastructure"
+    }
   }
 }
 

--- a/main.tf
+++ b/main.tf
@@ -81,6 +81,12 @@ provider "random" {
   version = "~> 2.0"
 }
 
+# Finally, we use the 'null' provider for some hacks, like
+# running a shell script when a resource changes.
+provider "null" {
+  version = "~> 2.1"
+}
+
 # ----------------------------------------------------
 
 # We separate our infrastructure into modules for


### PR DESCRIPTION
This pull request swaps our backend from S3/DynamoDB to [Terraform Enterprise's free tier](https://www.terraform.io/docs/enterprise/free/overview.html). This allows us to easily see when changes were made (rather than having to dig through the versioned S3 file) & will open us up to cool new features like remote plans & applies in the future.

**Note that any engineers who want to run Terraform will need to [create a Terraform.io account](https://app.terraform.io/account/new) and be invited to our team in order to run plans or applies in the future.** 👈 