### PR TITLE
Temporary: log user agents on incoming traffic.

### DIFF
--- a/dosomething/fastly-frontend/main.tf
+++ b/dosomething/fastly-frontend/main.tf
@@ -225,6 +225,6 @@ resource "fastly_service_v1" "frontend" {
     name    = "www.dosomething.org"
     address = "${element(split(":", var.papertrail_destination), 0)}"
     port    = "${element(split(":", var.papertrail_destination), 1)}"
-    format  = "%t '%r' status=%>s backend=%{X-Origin-Name}o microseconds=%D"
+    format  = "%t '%r' status=%>s backend=%{X-Origin-Name}o user-agent=%{User-Agent}i microseconds=%D"
   }
 }


### PR DESCRIPTION
I'm curious if we can learn a bit more about these traffic spikes in DoSomething/internal#478 by temporarily logging the `User-Agent` header on incoming requests following our next broadcast.