### PR TITLE
Put user agent in quotes for easier parsing.

### DIFF
--- a/dosomething/fastly-frontend/main.tf
+++ b/dosomething/fastly-frontend/main.tf
@@ -225,6 +225,6 @@ resource "fastly_service_v1" "frontend" {
     name    = "www.dosomething.org"
     address = "${element(split(":", var.papertrail_destination), 0)}"
     port    = "${element(split(":", var.papertrail_destination), 1)}"
-    format  = "%t '%r' status=%>s backend=%{X-Origin-Name}o user-agent=\"%{User-Agent}i\" microseconds=%D"
+    format  = "%t '%r' status=%>s backend=%{X-Origin-Name}o ip=\"%a\" user-agent=\"%{User-Agent}i\" microseconds=%D"
   }
 }

--- a/dosomething/fastly-frontend/main.tf
+++ b/dosomething/fastly-frontend/main.tf
@@ -225,6 +225,6 @@ resource "fastly_service_v1" "frontend" {
     name    = "www.dosomething.org"
     address = "${element(split(":", var.papertrail_destination), 0)}"
     port    = "${element(split(":", var.papertrail_destination), 1)}"
-    format  = "%t '%r' status=%>s backend=%{X-Origin-Name}o user-agent=%{User-Agent}i microseconds=%D"
+    format  = "%t '%r' status=%>s backend=%{X-Origin-Name}o user-agent=\"%{User-Agent}i\" microseconds=%D"
   }
 }


### PR DESCRIPTION
I noticed that this is a little hard to read (both visually, and via a script) after applying #180:

```
May 14 10:32:02 fastly www.dosomething.org: [14/May/2019:14:32:01 +0000] 'GET /next/assets/29c587e6cf1705132b046c5f2bd321df.woff HTTP/1.1' status=200 backend=F_dosomething_phoenix user-agent=Mozilla/5.0 (X11; CrOS x86_64 11647.104.0) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/73.0.3683.88 Safari/537.36 microseconds=139
```

This pull request adds some quotes around this value so it's easier to pull out. I've also added an `ip="…"` field so we can segment by unique traffic sources like we did with Heroku's router logs.

For reference, here's [Fastly's log format documentation](https://docs.fastly.com/guides/streaming-logs/custom-log-formats).