### PR TITLE
Updating Postgres version to reflect reality

### DIFF
--- a/quasar/main.tf
+++ b/quasar/main.tf
@@ -517,7 +517,7 @@ data "aws_ssm_parameter" "prod_password" {
 resource "aws_db_instance" "quasar-qa" {
   allocated_storage               = 1000
   engine                          = "postgres"
-  engine_version                  = "11.1"
+  engine_version                  = "11.2"
   instance_class                  = "db.m5.2xlarge"
   allow_major_version_upgrade     = true
   name                            = "quasar"


### PR DESCRIPTION
It seems that trying to run a major version upgrade through Terraform has no result, so I had to update through the GUI and then make the changes in Terraform to reflect which version we're on. This PR just updates the version from 11.1 to 11.2 which is the most recent version available.