### PR TITLE
Clean up log formatting.

### DIFF
--- a/dosomething-dev/fastly-backend/main.tf
+++ b/dosomething-dev/fastly-backend/main.tf
@@ -161,18 +161,9 @@ resource "fastly_service_v1" "backends-dev" {
   }
 
   papertrail {
-    name               = "northstar-dev"
-    address            = "${element(split(":", var.papertrail_destination), 0)}"
-    port               = "${element(split(":", var.papertrail_destination), 1)}"
-    format             = "${var.papertrail_log_format}"
-    response_condition = "response-northstar-dev"
-  }
-
-  papertrail {
-    name               = "rogue-dev"
-    address            = "${element(split(":", var.papertrail_destination), 0)}"
-    port               = "${element(split(":", var.papertrail_destination), 1)}"
-    format             = "${var.papertrail_log_format}"
-    response_condition = "response-rogue-dev"
+    name    = "backend"
+    address = "${element(split(":", var.papertrail_destination), 0)}"
+    port    = "${element(split(":", var.papertrail_destination), 1)}"
+    format  = "${var.papertrail_log_format}"
   }
 }

--- a/dosomething-dev/fastly-backend/main.tf
+++ b/dosomething-dev/fastly-backend/main.tf
@@ -10,7 +10,7 @@ variable "rogue_backend" {}
 variable "papertrail_destination" {}
 
 variable "papertrail_log_format" {
-  default = "%t '%r' status=%>s cache=%{X-Cache}o country=%{X-Fastly-Country-Code}o bytes=%b microseconds=%D"
+  default = "%t '%r' status=%>s cache=%{X-Cache}o country=%{X-Fastly-Country-Code}o ip=\"%a\" user-agent=\"%{User-Agent}i\" service=%{time.elapsed.msec}Vms"
 }
 
 resource "fastly_service_v1" "backends-dev" {
@@ -167,7 +167,7 @@ resource "fastly_service_v1" "backends-dev" {
     name               = "northstar-dev"
     address            = "${element(split(":", var.papertrail_destination), 0)}"
     port               = "${element(split(":", var.papertrail_destination), 1)}"
-    format             = "%t '%r' status=%>s bytes=%b microseconds=%D"
+    format             = "${var.papertrail_log_format}"
     response_condition = "response-northstar-dev"
   }
 

--- a/dosomething-dev/fastly-backend/main.tf
+++ b/dosomething-dev/fastly-backend/main.tf
@@ -8,10 +8,7 @@ variable "rogue_name" {}
 variable "rogue_domain" {}
 variable "rogue_backend" {}
 variable "papertrail_destination" {}
-
-variable "papertrail_log_format" {
-  default = "%t '%r' status=%>s cache=%{X-Cache}o country=%{X-Fastly-Country-Code}o ip=\"%a\" user-agent=\"%{User-Agent}i\" service=%{time.elapsed.msec}Vms"
-}
+variable "papertrail_log_format" {}
 
 resource "fastly_service_v1" "backends-dev" {
   name          = "Terraform: Backends (Development)"

--- a/dosomething-dev/fastly-frontend/main.tf
+++ b/dosomething-dev/fastly-frontend/main.tf
@@ -1,10 +1,7 @@
 variable "phoenix_name" {}
 variable "phoenix_backend" {}
 variable "papertrail_destination" {}
-
-variable "papertrail_log_format" {
-  default = "%t '%r' status=%>s cache=%{X-Cache}o country=%{X-Fastly-Country-Code}o ip=\"%a\" user-agent=\"%{User-Agent}i\" service=%{time.elapsed.msec}Vms"
-}
+variable "papertrail_log_format" {}
 
 resource "fastly_service_v1" "frontend-dev" {
   name          = "Terraform: Frontend (Development)"

--- a/dosomething-dev/fastly-frontend/main.tf
+++ b/dosomething-dev/fastly-frontend/main.tf
@@ -2,6 +2,10 @@ variable "phoenix_name" {}
 variable "phoenix_backend" {}
 variable "papertrail_destination" {}
 
+variable "papertrail_log_format" {
+  default = "%t '%r' status=%>s cache=%{X-Cache}o country=%{X-Fastly-Country-Code}o ip=\"%a\" user-agent=\"%{User-Agent}i\" service=%{time.elapsed.msec}Vms"
+}
+
 resource "fastly_service_v1" "frontend-dev" {
   name          = "Terraform: Frontend (Development)"
   force_destroy = true
@@ -174,6 +178,6 @@ resource "fastly_service_v1" "frontend-dev" {
     name    = "staging.dosomething.org"
     address = "${element(split(":", var.papertrail_destination), 0)}"
     port    = "${element(split(":", var.papertrail_destination), 1)}"
-    format  = "%t '%r' status=%>s backend=%{X-Origin-Name}o microseconds=%D"
+    format  = "${var.papertrail_log_format}"
   }
 }

--- a/dosomething-dev/fastly-frontend/main.tf
+++ b/dosomething-dev/fastly-frontend/main.tf
@@ -172,7 +172,7 @@ resource "fastly_service_v1" "frontend-dev" {
   }
 
   papertrail {
-    name    = "staging.dosomething.org"
+    name    = "frontend"
     address = "${element(split(":", var.papertrail_destination), 0)}"
     port    = "${element(split(":", var.papertrail_destination), 1)}"
     format  = "${var.papertrail_log_format}"

--- a/dosomething-dev/main.tf
+++ b/dosomething-dev/main.tf
@@ -4,6 +4,10 @@ variable "rogue_pipeline" {}
 variable "papertrail_destination" {}
 variable "papertrail_destination_fastly" {}
 
+locals {
+  papertrail_log_format = "%t '%r' status=%>s cache=%{X-Cache}o country=%{X-Fastly-Country-Code}o ip=\"%a\" user-agent=\"%{User-Agent}i\" service=%{time.elapsed.msec}Vms"
+}
+
 module "fastly-frontend" {
   source = "fastly-frontend"
 
@@ -11,6 +15,7 @@ module "fastly-frontend" {
   phoenix_backend = "${module.phoenix.backend}"
 
   papertrail_destination = "${var.papertrail_destination_fastly}"
+  papertrail_log_format  = "${local.papertrail_log_format}"
 }
 
 module "fastly-backend" {
@@ -29,6 +34,7 @@ module "fastly-backend" {
   rogue_backend = "${module.rogue.backend}"
 
   papertrail_destination = "${var.papertrail_destination_fastly}"
+  papertrail_log_format  = "${local.papertrail_log_format}"
 }
 
 module "graphql" {

--- a/dosomething-dev/main.tf
+++ b/dosomething-dev/main.tf
@@ -5,7 +5,7 @@ variable "papertrail_destination" {}
 variable "papertrail_destination_fastly" {}
 
 locals {
-  papertrail_log_format = "%t '%r' status=%>s cache=%{X-Cache}o country=%{X-Fastly-Country-Code}o ip=\"%a\" user-agent=\"%{User-Agent}i\" service=%{time.elapsed.msec}Vms"
+  papertrail_log_format = "%t '%r' status=%>s app=%{X-Origin-Name}o cache=%{X-Cache}o country=%{X-Fastly-Country-Code}o ip=\"%a\" user-agent=\"%{User-Agent}i\" service=%{time.elapsed.msec}Vms"
 }
 
 module "fastly-frontend" {

--- a/dosomething-qa/fastly-backend/main.tf
+++ b/dosomething-qa/fastly-backend/main.tf
@@ -7,7 +7,7 @@ variable "rogue_backend" {}
 variable "papertrail_destination" {}
 
 variable "papertrail_log_format" {
-  default = "%t '%r' status=%>s cache=%{X-Cache}o country=%{X-Fastly-Country-Code}o bytes=%b microseconds=%D"
+  default = "%t '%r' status=%>s cache=%{X-Cache}o country=%{X-Fastly-Country-Code}o ip=\"%a\" user-agent=\"%{User-Agent}i\" service=%{time.elapsed.msec}Vms"
 }
 
 resource "fastly_service_v1" "backends-qa" {

--- a/dosomething-qa/fastly-backend/main.tf
+++ b/dosomething-qa/fastly-backend/main.tf
@@ -5,10 +5,7 @@ variable "rogue_name" {}
 variable "rogue_domain" {}
 variable "rogue_backend" {}
 variable "papertrail_destination" {}
-
-variable "papertrail_log_format" {
-  default = "%t '%r' status=%>s cache=%{X-Cache}o country=%{X-Fastly-Country-Code}o ip=\"%a\" user-agent=\"%{User-Agent}i\" service=%{time.elapsed.msec}Vms"
-}
+variable "papertrail_log_format" {}
 
 resource "fastly_service_v1" "backends-qa" {
   name          = "Terraform: Backends (QA)"

--- a/dosomething-qa/fastly-backend/main.tf
+++ b/dosomething-qa/fastly-backend/main.tf
@@ -158,18 +158,9 @@ resource "fastly_service_v1" "backends-qa" {
   }
 
   papertrail {
-    name               = "northstar-qa"
-    address            = "${element(split(":", var.papertrail_destination), 0)}"
-    port               = "${element(split(":", var.papertrail_destination), 1)}"
-    format             = "${var.papertrail_log_format}"
-    response_condition = "response-northstar-qa"
-  }
-
-  papertrail {
-    name               = "rogue-qa"
-    address            = "${element(split(":", var.papertrail_destination), 0)}"
-    port               = "${element(split(":", var.papertrail_destination), 1)}"
-    format             = "${var.papertrail_log_format}"
-    response_condition = "response-rogue-qa"
+    name    = "backend"
+    address = "${element(split(":", var.papertrail_destination), 0)}"
+    port    = "${element(split(":", var.papertrail_destination), 1)}"
+    format  = "${var.papertrail_log_format}"
   }
 }

--- a/dosomething-qa/fastly-frontend/main.tf
+++ b/dosomething-qa/fastly-frontend/main.tf
@@ -1,10 +1,7 @@
 variable "phoenix_name" {}
 variable "phoenix_backend" {}
 variable "papertrail_destination" {}
-
-variable "papertrail_log_format" {
-  default = "%t '%r' status=%>s cache=%{X-Cache}o country=%{X-Fastly-Country-Code}o ip=\"%a\" user-agent=\"%{User-Agent}i\" service=%{time.elapsed.msec}Vms"
-}
+variable "papertrail_log_format" {}
 
 resource "fastly_service_v1" "frontend-qa" {
   name          = "Terraform: Frontend (QA)"

--- a/dosomething-qa/fastly-frontend/main.tf
+++ b/dosomething-qa/fastly-frontend/main.tf
@@ -2,6 +2,10 @@ variable "phoenix_name" {}
 variable "phoenix_backend" {}
 variable "papertrail_destination" {}
 
+variable "papertrail_log_format" {
+  default = "%t '%r' status=%>s cache=%{X-Cache}o country=%{X-Fastly-Country-Code}o ip=\"%a\" user-agent=\"%{User-Agent}i\" service=%{time.elapsed.msec}Vms"
+}
+
 resource "fastly_service_v1" "frontend-qa" {
   name          = "Terraform: Frontend (QA)"
   force_destroy = true
@@ -200,6 +204,6 @@ resource "fastly_service_v1" "frontend-qa" {
     name    = "qa.dosomething.org"
     address = "${element(split(":", var.papertrail_destination), 0)}"
     port    = "${element(split(":", var.papertrail_destination), 1)}"
-    format  = "%t '%r' status=%>s backend=%{X-Origin-Name}o microseconds=%D"
+    format  = "${var.papertrail_log_format}"
   }
 }

--- a/dosomething-qa/fastly-frontend/main.tf
+++ b/dosomething-qa/fastly-frontend/main.tf
@@ -198,7 +198,7 @@ resource "fastly_service_v1" "frontend-qa" {
   }
 
   papertrail {
-    name    = "qa.dosomething.org"
+    name    = "frontend"
     address = "${element(split(":", var.papertrail_destination), 0)}"
     port    = "${element(split(":", var.papertrail_destination), 1)}"
     format  = "${var.papertrail_log_format}"

--- a/dosomething-qa/main.tf
+++ b/dosomething-qa/main.tf
@@ -4,6 +4,10 @@ variable "rogue_pipeline" {}
 variable "papertrail_destination" {}
 variable "papertrail_destination_fastly" {}
 
+locals {
+  papertrail_log_format = "%t '%r' status=%>s cache=%{X-Cache}o country=%{X-Fastly-Country-Code}o ip=\"%a\" user-agent=\"%{User-Agent}i\" service=%{time.elapsed.msec}Vms"
+}
+
 module "chompy" {
   source = "../applications/chompy"
 
@@ -17,6 +21,7 @@ module "fastly-frontend" {
   phoenix_backend = "${module.phoenix.backend}"
 
   papertrail_destination = "${var.papertrail_destination_fastly}"
+  papertrail_log_format  = "${local.papertrail_log_format}"
 }
 
 module "fastly-backend" {
@@ -31,6 +36,7 @@ module "fastly-backend" {
   rogue_backend = "${module.rogue.backend}"
 
   papertrail_destination = "${var.papertrail_destination_fastly}"
+  papertrail_log_format  = "${local.papertrail_log_format}"
 }
 
 module "graphql" {

--- a/dosomething-qa/main.tf
+++ b/dosomething-qa/main.tf
@@ -5,7 +5,7 @@ variable "papertrail_destination" {}
 variable "papertrail_destination_fastly" {}
 
 locals {
-  papertrail_log_format = "%t '%r' status=%>s cache=%{X-Cache}o country=%{X-Fastly-Country-Code}o ip=\"%a\" user-agent=\"%{User-Agent}i\" service=%{time.elapsed.msec}Vms"
+  papertrail_log_format = "%t '%r' status=%>s app=%{X-Origin-Name}o cache=%{X-Cache}o country=%{X-Fastly-Country-Code}o ip=\"%a\" user-agent=\"%{User-Agent}i\" service=%{time.elapsed.msec}Vms"
 }
 
 module "chompy" {

--- a/dosomething/fastly-backend/main.tf
+++ b/dosomething/fastly-backend/main.tf
@@ -8,10 +8,7 @@ variable "rogue_name" {}
 variable "rogue_domain" {}
 variable "rogue_backend" {}
 variable "papertrail_destination" {}
-
-variable "papertrail_log_format" {
-  default = "%t '%r' status=%>s cache=%{X-Cache}o country=%{X-Fastly-Country-Code}o bytes=%b microseconds=%D"
-}
+variable "papertrail_log_format" {}
 
 resource "fastly_service_v1" "backends" {
   name          = "Terraform: Backends"
@@ -189,26 +186,9 @@ resource "fastly_service_v1" "backends" {
   }
 
   papertrail {
-    name               = "northstar"
-    address            = "${element(split(":", var.papertrail_destination), 0)}"
-    port               = "${element(split(":", var.papertrail_destination), 1)}"
-    format             = "${var.papertrail_log_format}"
-    response_condition = "response-northstar"
-  }
-
-  papertrail {
-    name               = "phoenix-preview"
-    address            = "${element(split(":", var.papertrail_destination), 0)}"
-    port               = "${element(split(":", var.papertrail_destination), 1)}"
-    format             = "${var.papertrail_log_format}"
-    response_condition = "response-phoenix-preview"
-  }
-
-  papertrail {
-    name               = "rogue"
-    address            = "${element(split(":", var.papertrail_destination), 0)}"
-    port               = "${element(split(":", var.papertrail_destination), 1)}"
-    format             = "${var.papertrail_log_format}"
-    response_condition = "response-rogue"
+    name    = "backend"
+    address = "${element(split(":", var.papertrail_destination), 0)}"
+    port    = "${element(split(":", var.papertrail_destination), 1)}"
+    format  = "${var.papertrail_log_format}"
   }
 }

--- a/dosomething/fastly-frontend/main.tf
+++ b/dosomething/fastly-frontend/main.tf
@@ -3,6 +3,7 @@ variable "assets_backend" {}
 variable "phoenix_name" {}
 variable "phoenix_backend" {}
 variable "papertrail_destination" {}
+variable "papertrail_log_format" {}
 
 resource "fastly_service_v1" "frontend" {
   name          = "Terraform: Frontend"
@@ -222,9 +223,9 @@ resource "fastly_service_v1" "frontend" {
   }
 
   papertrail {
-    name    = "www.dosomething.org"
+    name    = "frontend"
     address = "${element(split(":", var.papertrail_destination), 0)}"
     port    = "${element(split(":", var.papertrail_destination), 1)}"
-    format  = "%t '%r' status=%>s backend=%{X-Origin-Name}o ip=\"%a\" user-agent=\"%{User-Agent}i\" microseconds=%D"
+    format  = "${var.papertrail_log_format}"
   }
 }

--- a/dosomething/fastly-frontend/main.tf
+++ b/dosomething/fastly-frontend/main.tf
@@ -225,6 +225,6 @@ resource "fastly_service_v1" "frontend" {
     name    = "www.dosomething.org"
     address = "${element(split(":", var.papertrail_destination), 0)}"
     port    = "${element(split(":", var.papertrail_destination), 1)}"
-    format  = "%t '%r' status=%>s backend=%{X-Origin-Name}o ip=\"%a\" ms=%{time.elapsed.msec}V"
+    format  = "%t '%r' status=%>s backend=%{X-Origin-Name}o ip=\"%a\" service=%{time.elapsed.msec}Vms"
   }
 }

--- a/dosomething/fastly-frontend/main.tf
+++ b/dosomething/fastly-frontend/main.tf
@@ -225,6 +225,6 @@ resource "fastly_service_v1" "frontend" {
     name    = "www.dosomething.org"
     address = "${element(split(":", var.papertrail_destination), 0)}"
     port    = "${element(split(":", var.papertrail_destination), 1)}"
-    format  = "%t '%r' status=%>s backend=%{X-Origin-Name}o ip=\"%a\" user-agent=\"%{User-Agent}i\" microseconds=%D"
+    format  = "%t '%r' status=%>s backend=%{X-Origin-Name}o ip=\"%a\" microseconds=%D"
   }
 }

--- a/dosomething/fastly-frontend/main.tf
+++ b/dosomething/fastly-frontend/main.tf
@@ -225,6 +225,6 @@ resource "fastly_service_v1" "frontend" {
     name    = "www.dosomething.org"
     address = "${element(split(":", var.papertrail_destination), 0)}"
     port    = "${element(split(":", var.papertrail_destination), 1)}"
-    format  = "%t '%r' status=%>s backend=%{X-Origin-Name}o ip=\"%a\" service=%{time.elapsed.msec}Vms"
+    format  = "%t '%r' status=%>s backend=%{X-Origin-Name}o ip=\"%a\" user-agent=\"%{User-Agent}i\" microseconds=%D"
   }
 }

--- a/dosomething/fastly-frontend/main.tf
+++ b/dosomething/fastly-frontend/main.tf
@@ -225,6 +225,6 @@ resource "fastly_service_v1" "frontend" {
     name    = "www.dosomething.org"
     address = "${element(split(":", var.papertrail_destination), 0)}"
     port    = "${element(split(":", var.papertrail_destination), 1)}"
-    format  = "%t '%r' status=%>s backend=%{X-Origin-Name}o ip=\"%a\" microseconds=%D"
+    format  = "%t '%r' status=%>s backend=%{X-Origin-Name}o ip=\"%a\" ms=%{time.elapsed.msec}V"
   }
 }

--- a/dosomething/main.tf
+++ b/dosomething/main.tf
@@ -4,6 +4,10 @@ variable "rogue_pipeline" {}
 variable "papertrail_destination" {}
 variable "papertrail_destination_fastly" {}
 
+locals {
+  papertrail_log_format = "%t '%r' status=%>s app=%{X-Origin-Name}o cache=%{X-Cache}o country=%{X-Fastly-Country-Code}o ip=\"%a\" user-agent=\"%{User-Agent}i\" service=%{time.elapsed.msec}Vms"
+}
+
 module "assets" {
   source = "../applications/static"
 
@@ -26,6 +30,7 @@ module "fastly-frontend" {
   phoenix_backend = "${module.phoenix.backend}"
 
   papertrail_destination = "${var.papertrail_destination_fastly}"
+  papertrail_log_format  = "${local.papertrail_log_format}"
 }
 
 module "fastly-backend" {
@@ -44,6 +49,7 @@ module "fastly-backend" {
   rogue_backend = "${module.rogue.backend}"
 
   papertrail_destination = "${var.papertrail_destination_fastly}"
+  papertrail_log_format  = "${local.papertrail_log_format}"
 }
 
 module "graphql" {


### PR DESCRIPTION
This pull request ~removes the temporary `user-agent` field added in #181, and~ swaps elapsed time to be logged in milliseconds for readability & consistency with other systems, like [Heroku's router logs](https://devcenter.heroku.com/articles/http-routing#heroku-router-log-format).