### PR TITLE
Stop managing Rogue's web dynos with Terraform.

### DIFF
--- a/applications/rogue/main.tf
+++ b/applications/rogue/main.tf
@@ -61,8 +61,10 @@ module "app" {
   pipeline    = "${var.pipeline}"
   environment = "${var.environment}"
 
-  web_size  = "${var.environment == "production" ? "Standard-2x" : "Standard-1x"}"
-  web_scale = "${var.environment == "production" ? 2 : 1}"
+  web_size = "${var.environment == "production" ? "Standard-2x" : "Standard-1x"}"
+
+  # We use autoscaling in production, so don't try to manage dynos there.
+  ignore_web = "${var.environment == "production"}"
 
   config_vars = "${merge(
     module.database.config_vars,

--- a/quasar/main.tf
+++ b/quasar/main.tf
@@ -530,7 +530,7 @@ resource "aws_db_instance" "quasar-qa" {
   copy_tags_to_snapshot           = true
   monitoring_interval             = "10"
   publicly_accessible             = true
-  enabled_cloudwatch_logs_exports = ["postgresql"]
+  enabled_cloudwatch_logs_exports = ["postgresql", "upgrade"]
 }
 
 resource "aws_db_instance" "quasar" {


### PR DESCRIPTION
This pull request sets the `ignore_web` flag for Rogue's production application, because we'll be handling autoscaling for this app with [HireFire](https://hirefire.io) (like we do for Northstar). (I've also removed the `web_scale` override since `1` is the default.)