### PR TITLE
A little more log formatting cleanup.

### DIFF
--- a/dosomething-dev/fastly-backend/main.tf
+++ b/dosomething-dev/fastly-backend/main.tf
@@ -157,7 +157,7 @@ resource "fastly_service_v1" "backends-dev" {
   snippet {
     name    = "Shared - Set X-Origin-Name Header"
     type    = "fetch"
-    content = "${file("${path.root}/shared/origin_name.vcl")}"
+    content = "${file("${path.root}/shared/app_name.vcl")}"
   }
 
   papertrail {

--- a/dosomething-dev/fastly-frontend/main.tf
+++ b/dosomething-dev/fastly-frontend/main.tf
@@ -168,7 +168,7 @@ resource "fastly_service_v1" "frontend-dev" {
   snippet {
     name    = "Shared - Set X-Origin-Name Header"
     type    = "fetch"
-    content = "${file("${path.root}/shared/origin_name.vcl")}"
+    content = "${file("${path.root}/shared/app_name.vcl")}"
   }
 
   papertrail {

--- a/dosomething-dev/main.tf
+++ b/dosomething-dev/main.tf
@@ -5,7 +5,7 @@ variable "papertrail_destination" {}
 variable "papertrail_destination_fastly" {}
 
 locals {
-  papertrail_log_format = "%t '%r' status=%>s app=%{X-Origin-Name}o cache=%{X-Cache}o country=%{X-Fastly-Country-Code}o ip=\"%a\" user-agent=\"%{User-Agent}i\" service=%{time.elapsed.msec}Vms"
+  papertrail_log_format = "%t '%r' status=%>s app=%{X-Origin-Name}o cache=\"%{X-Cache}o\" country=%{X-Fastly-Country-Code}o ip=\"%a\" user-agent=\"%{User-Agent}i\" service=%{time.elapsed.msec}Vms"
 }
 
 module "fastly-frontend" {

--- a/dosomething-dev/main.tf
+++ b/dosomething-dev/main.tf
@@ -5,7 +5,7 @@ variable "papertrail_destination" {}
 variable "papertrail_destination_fastly" {}
 
 locals {
-  papertrail_log_format = "%t '%r' status=%>s app=%{X-Origin-Name}o cache=\"%{X-Cache}o\" country=%{X-Fastly-Country-Code}o ip=\"%a\" user-agent=\"%{User-Agent}i\" service=%{time.elapsed.msec}Vms"
+  papertrail_log_format = "%t '%r' status=%>s app=%{X-Application-Name}o cache=\"%{X-Cache}o\" country=%{X-Fastly-Country-Code}o ip=\"%a\" user-agent=\"%{User-Agent}i\" service=%{time.elapsed.msec}Vms"
 }
 
 module "fastly-frontend" {

--- a/dosomething-qa/fastly-backend/main.tf
+++ b/dosomething-qa/fastly-backend/main.tf
@@ -154,7 +154,7 @@ resource "fastly_service_v1" "backends-qa" {
   snippet {
     name    = "Shared - Set X-Origin-Name Header"
     type    = "fetch"
-    content = "${file("${path.root}/shared/origin_name.vcl")}"
+    content = "${file("${path.root}/shared/app_name.vcl")}"
   }
 
   papertrail {

--- a/dosomething-qa/fastly-frontend/main.tf
+++ b/dosomething-qa/fastly-frontend/main.tf
@@ -180,7 +180,7 @@ resource "fastly_service_v1" "frontend-qa" {
   snippet {
     name    = "Shared - Set X-Origin-Name Header"
     type    = "fetch"
-    content = "${file("${path.root}/shared/origin_name.vcl")}"
+    content = "${file("${path.root}/shared/app_name.vcl")}"
   }
 
   snippet {

--- a/dosomething-qa/main.tf
+++ b/dosomething-qa/main.tf
@@ -5,7 +5,7 @@ variable "papertrail_destination" {}
 variable "papertrail_destination_fastly" {}
 
 locals {
-  papertrail_log_format = "%t '%r' status=%>s app=%{X-Origin-Name}o cache=%{X-Cache}o country=%{X-Fastly-Country-Code}o ip=\"%a\" user-agent=\"%{User-Agent}i\" service=%{time.elapsed.msec}Vms"
+  papertrail_log_format = "%t '%r' status=%>s app=%{X-Origin-Name}o cache=\"%{X-Cache}o\" country=%{X-Fastly-Country-Code}o ip=\"%a\" user-agent=\"%{User-Agent}i\" service=%{time.elapsed.msec}Vms"
 }
 
 module "chompy" {

--- a/dosomething-qa/main.tf
+++ b/dosomething-qa/main.tf
@@ -5,7 +5,7 @@ variable "papertrail_destination" {}
 variable "papertrail_destination_fastly" {}
 
 locals {
-  papertrail_log_format = "%t '%r' status=%>s app=%{X-Origin-Name}o cache=\"%{X-Cache}o\" country=%{X-Fastly-Country-Code}o ip=\"%a\" user-agent=\"%{User-Agent}i\" service=%{time.elapsed.msec}Vms"
+  papertrail_log_format = "%t '%r' status=%>s app=%{X-Application-Name}o cache=\"%{X-Cache}o\" country=%{X-Fastly-Country-Code}o ip=\"%a\" user-agent=\"%{User-Agent}i\" service=%{time.elapsed.msec}Vms"
 }
 
 module "chompy" {

--- a/dosomething/fastly-backend/main.tf
+++ b/dosomething/fastly-backend/main.tf
@@ -182,7 +182,7 @@ resource "fastly_service_v1" "backends" {
   snippet {
     name    = "Shared - Set X-Origin-Name Header"
     type    = "fetch"
-    content = "${file("${path.root}/shared/origin_name.vcl")}"
+    content = "${file("${path.root}/shared/app_name.vcl")}"
   }
 
   papertrail {

--- a/dosomething/fastly-frontend/main.tf
+++ b/dosomething/fastly-frontend/main.tf
@@ -205,7 +205,7 @@ resource "fastly_service_v1" "frontend" {
   snippet {
     name    = "Shared - Set X-Origin-Name Header"
     type    = "fetch"
-    content = "${file("${path.root}/shared/origin_name.vcl")}"
+    content = "${file("${path.root}/shared/app_name.vcl")}"
   }
 
   snippet {

--- a/dosomething/main.tf
+++ b/dosomething/main.tf
@@ -5,7 +5,7 @@ variable "papertrail_destination" {}
 variable "papertrail_destination_fastly" {}
 
 locals {
-  papertrail_log_format = "%t '%r' status=%>s app=%{X-Origin-Name}o cache=\"%{X-Cache}o\" country=%{X-Fastly-Country-Code}o ip=\"%a\" user-agent=\"%{User-Agent}i\" service=%{time.elapsed.msec}Vms"
+  papertrail_log_format = "%t '%r' status=%>s app=%{X-Application-Name}o cache=\"%{X-Cache}o\" country=%{X-Fastly-Country-Code}o ip=\"%a\" user-agent=\"%{User-Agent}i\" service=%{time.elapsed.msec}Vms"
 }
 
 module "assets" {

--- a/dosomething/main.tf
+++ b/dosomething/main.tf
@@ -5,7 +5,7 @@ variable "papertrail_destination" {}
 variable "papertrail_destination_fastly" {}
 
 locals {
-  papertrail_log_format = "%t '%r' status=%>s app=%{X-Origin-Name}o cache=%{X-Cache}o country=%{X-Fastly-Country-Code}o ip=\"%a\" user-agent=\"%{User-Agent}i\" service=%{time.elapsed.msec}Vms"
+  papertrail_log_format = "%t '%r' status=%>s app=%{X-Origin-Name}o cache=\"%{X-Cache}o\" country=%{X-Fastly-Country-Code}o ip=\"%a\" user-agent=\"%{User-Agent}i\" service=%{time.elapsed.msec}Vms"
 }
 
 module "assets" {

--- a/shared/app_name.vcl
+++ b/shared/app_name.vcl
@@ -1,6 +1,6 @@
 # Mark which backend is serving the request on a header. (Or forward
 # along the name of the backend if this is running on a shield node.)
 # This is handy for debugging & logged in Papertrail. <goo.gl/TWF4kz>
-if (! beresp.http.X-Origin-Name) {
-  set beresp.http.X-Origin-Name = regsub(beresp.backend.name, "^(.*)--", "");
+if (! beresp.http.X-Application-Name) {
+  set beresp.http.X-Application-Name = regsub(beresp.backend.name, "^(.*)--", "");
 }

--- a/shared/app_name.vcl
+++ b/shared/app_name.vcl
@@ -2,5 +2,12 @@
 # along the name of the backend if this is running on a shield node.)
 # This is handy for debugging & logged in Papertrail. <goo.gl/TWF4kz>
 if (! beresp.http.X-Application-Name) {
-  set beresp.http.X-Application-Name = regsub(beresp.backend.name, "^(.*)--", "");
+  declare local var.application_name STRING;
+
+  # Remove unhelpful internal Fastly identifier.
+  set var.application_name = regsub(beresp.backend.name, "^(.*)--", "");
+
+  # Format header by our convention (e.g. "F_dosomething_phoenix" to "dosomething-phoenix"):
+  set beresp.http.X-Application-Name = regsub(regsub(var.application_name, "F_", ""), "_", "-");
 }
+


### PR DESCRIPTION
This pull request adds quotes around the `cache` log field, so shielded requests (e.g. `cache="HIT, MISS"` are a little easier to read and search for. I've also renamed the `X-Origin-Name` header to `X-Application-Name` for clarity (since it's really about which app/backend serves the request).

Finally, I've reformatted that header to be more consistent with the "real" application names (for example, changing `F_dosomething_phoenix_qa` into `dosomething-phoenix-qa`). ([fiddle demo](https://fiddle.fastlydemo.net/fiddle/0d90256a))