### PR TITLE
Fix issue where app name wasn't completely transformed.

### DIFF
--- a/shared/app_name.vcl
+++ b/shared/app_name.vcl
@@ -8,6 +8,6 @@ if (! beresp.http.X-Application-Name) {
   set var.application_name = regsub(beresp.backend.name, "^(.*)--", "");
 
   # Format header by our convention (e.g. "F_dosomething_phoenix" to "dosomething-phoenix"):
-  set beresp.http.X-Application-Name = regsub(regsub(var.application_name, "F_", ""), "_", "-");
+  set beresp.http.X-Application-Name = regsuball(regsub(var.application_name, "F_", ""), "_", "-");
 }
 


### PR DESCRIPTION
Whoops. The [`regsub`](https://docs.fastly.com/vcl/functions/regsub/) helper only makes a single replacement, so I need to use [`regsuball`](https://docs.fastly.com/vcl/functions/regsuball/) here! (This fixes some awkward logs, like `app=dosomething-northstar_qa`.... so close!!)