### PR TITLE
Setting Quasar Prod PostgreSQL 11 statement_timeout to enable Fivetran syncing for Snowplow.

### DIFF
--- a/quasar/main.tf
+++ b/quasar/main.tf
@@ -500,7 +500,7 @@ resource "aws_db_parameter_group" "quasar-prod-pg11" {
   # Increase statement timeout for Fivetran Snowplow sync.
   parameter {
     name  = "statement_timeout"
-    value = ""
+    value = "0"
   }
 }
 

--- a/quasar/main.tf
+++ b/quasar/main.tf
@@ -496,6 +496,12 @@ resource "aws_db_parameter_group" "quasar-prod-pg11" {
     name  = "log_duration"
     value = "0"
   }
+
+  # Increase statement timeout for Fivetran Snowplow sync.
+  parameter {
+    name  = "statement_timeout"
+    value = ""
+  }
 }
 
 data "aws_ssm_parameter" "qa_username" {

--- a/quasar/main.tf
+++ b/quasar/main.tf
@@ -496,6 +496,12 @@ resource "aws_db_parameter_group" "quasar-prod-pg11" {
     name  = "log_duration"
     value = "0"
   }
+
+  # Increase statement timeout for Fivetran Snowplow sync.
+  parameter {
+    name  = "statement_timeout"
+    value = "7200000"
+  }
 }
 
 data "aws_ssm_parameter" "qa_username" {

--- a/quasar/main.tf
+++ b/quasar/main.tf
@@ -496,12 +496,6 @@ resource "aws_db_parameter_group" "quasar-prod-pg11" {
     name  = "log_duration"
     value = "0"
   }
-
-  # Increase statement timeout for Fivetran Snowplow sync.
-  parameter {
-    name  = "statement_timeout"
-    value = "7200000"
-  }
 }
 
 data "aws_ssm_parameter" "qa_username" {

--- a/quasar/main.tf
+++ b/quasar/main.tf
@@ -497,7 +497,7 @@ resource "aws_db_parameter_group" "quasar-prod-pg11" {
     value = "0"
   }
 
-  # Increase statement timeout for Fivetran Snowplow sync.
+  # Set to default value globally per https://git.io/fjghW.
   parameter {
     name  = "statement_timeout"
     value = "0"


### PR DESCRIPTION
* Fivetran sync for Snowplow data is large enough that it requires a larger statement timeout. The recommended value for Snowplow is `3600000`, but the sync is taking longer than that, so setting to double the value, `7200000`.