### PR TITLE
Update provider versions.

### DIFF
--- a/components/heroku_app/main.tf
+++ b/components/heroku_app/main.tf
@@ -147,7 +147,7 @@ resource "heroku_app" "app" {
     name = "dosomething"
   }
 
-  config_vars = ["${merge(local.config_vars[var.framework], var.config_vars)}"]
+  config_vars = "${merge(local.config_vars[var.framework], var.config_vars)}"
 
   buildpacks = "${local.buildpacks[var.framework]}"
 

--- a/main.tf
+++ b/main.tf
@@ -37,7 +37,7 @@ terraform {
 # in front of (most of) our services & handles caching,
 # backend-routing, geolocation, redirects, etc.
 provider "fastly" {
-  version = "~> 0.4"
+  version = "~> 0.6"
   api_key = "${var.fastly_api_key}"
 }
 

--- a/main.tf
+++ b/main.tf
@@ -57,7 +57,7 @@ provider "heroku" {
 # some legacy servers on EC2. AWS credentials are stored
 # using the `aws` CLI (see installation instructions).
 provider "aws" {
-  version = "~> 1.56"
+  version = "~> 2.15"
   region  = "us-east-1"
   profile = "terraform"
 }

--- a/main.tf
+++ b/main.tf
@@ -47,7 +47,7 @@ provider "fastly" {
 # visibility & to make cross-cloud dependencies (like AWS
 # resources or Fastly backends) easier to hook up.
 provider "heroku" {
-  version = "~> 1.5"
+  version = "~> 2.0"
   email   = "${var.heroku_email}"
   api_key = "${var.heroku_api_key}"
 }

--- a/main.tf
+++ b/main.tf
@@ -73,7 +73,7 @@ provider "aws" {
 # The template provider is used to generate files with
 # interpolated variables (like JSON or VCL).
 provider "template" {
-  version = "~> 1.0"
+  version = "~> 2.1"
 }
 
 # The random provider is used for secret generation.

--- a/quasar/main.tf
+++ b/quasar/main.tf
@@ -536,6 +536,7 @@ resource "aws_db_instance" "quasar-qa" {
   copy_tags_to_snapshot           = true
   monitoring_interval             = "10"
   publicly_accessible             = true
+  performance_insights_enabled    = true
   enabled_cloudwatch_logs_exports = ["postgresql", "upgrade"]
 }
 
@@ -554,5 +555,6 @@ resource "aws_db_instance" "quasar" {
   copy_tags_to_snapshot           = true
   monitoring_interval             = "10"
   publicly_accessible             = true
+  performance_insights_enabled    = true
   enabled_cloudwatch_logs_exports = ["postgresql", "upgrade"]
 }


### PR DESCRIPTION
This pull request updates our Terraform provider versions to the latest available release, paving the way for [#166288730](https://www.pivotaltracker.com/story/show/166288730) in an upcoming sprint. Notably:

- The newer AWS provider adds support for Performance Insights on RDS instances, so I've gone ahead and set that to `true` for Quasar so it isn't reverted to the default (disabled) state.
 - The newer AWS provider changes the `distribution` param for [cloudwatch_log_subscription_filter](https://www.terraform.io/docs/providers/aws/r/cloudwatch_log_subscription_filter.html) to be set to `""` (as expected, since these aren't targeting Amazon Kinesis).
- The newer Heroku provider updates [heroku_app](https://www.terraform.io/docs/providers/heroku/r/app.html)'s `config_vars` to be stored as a map, rather than a list containing a map (which was always awkward). This results in a pretty hefty diff for "setting" the new values, but should be no effective change.
- The new Heroku provider also introduces a `sensitive_config_vars` parameter for [heroku_app](https://www.terraform.io/docs/providers/heroku/r/app.html) that we can move passwords & keys into so they're hidden in diffs.