### PR TITLE
Remove GDPR redirect logic.

### DIFF
--- a/components/lambda_function/main.tf
+++ b/components/lambda_function/main.tf
@@ -60,6 +60,7 @@ resource "aws_cloudwatch_log_subscription_filter" "papertrail_subscription" {
   name            = "papertrail_forwarder"
   log_group_name  = "${aws_cloudwatch_log_group.log_group.name}"
   destination_arn = "${var.logger}"
+  distribution    = "ByLogStream"
 
   # Forward all log messages:
   filter_pattern = ""

--- a/components/mariadb_instance/main.tf
+++ b/components/mariadb_instance/main.tf
@@ -137,7 +137,7 @@ resource "aws_db_instance" "database" {
 
 # Configure a MySQL provider for this instance.
 provider "mysql" {
-  version  = "~> 1.5"
+  version  = "~> 1.6"
   endpoint = "${aws_db_instance.database.endpoint}"
   username = "${aws_db_instance.database.username}"
   password = "${aws_db_instance.database.password}"

--- a/dosomething-dev/fastly-backend/main.tf
+++ b/dosomething-dev/fastly-backend/main.tf
@@ -137,24 +137,6 @@ resource "fastly_service_v1" "backends-dev" {
   }
 
   snippet {
-    name    = "GDPR - Redirects Table"
-    type    = "init"
-    content = "${file("${path.root}/shared/gdpr_init.vcl")}"
-  }
-
-  snippet {
-    name    = "GDPR - Trigger Redirect"
-    type    = "recv"
-    content = "${file("${path.root}/shared/gdpr_recv.vcl")}"
-  }
-
-  snippet {
-    name    = "GDPR - Handle Redirect"
-    type    = "error"
-    content = "${file("${path.root}/shared/gdpr_error.vcl")}"
-  }
-
-  snippet {
     name    = "Shared - Set X-Origin-Name Header"
     type    = "fetch"
     content = "${file("${path.root}/shared/app_name.vcl")}"

--- a/dosomething-dev/fastly-frontend/main.tf
+++ b/dosomething-dev/fastly-frontend/main.tf
@@ -28,7 +28,7 @@ resource "fastly_service_v1" "frontend-dev" {
     type = "REQUEST"
     name = "is-authenticated"
 
-    # We want exclude logged-in users from Fastly caching (since their responses will 
+    # We want exclude logged-in users from Fastly caching (since their responses will
     # likely include user-specific content) but still cache static assets at the edge.
     statement = "req.http.Cookie ~ \"laravel_session=\" && req.url !~ \"\\.(css|js|woff|otf|ttf|svg)(\\?.*)?$\""
   }
@@ -145,24 +145,6 @@ resource "fastly_service_v1" "frontend-dev" {
     name    = "ProjectPages - Handle Redirect"
     type    = "error"
     content = "${file("${path.module}/legacy_redirects_error.vcl")}"
-  }
-
-  snippet {
-    name    = "GDPR - Redirects Table"
-    type    = "init"
-    content = "${file("${path.root}/shared/gdpr_init.vcl")}"
-  }
-
-  snippet {
-    name    = "GDPR - Trigger Redirect"
-    type    = "recv"
-    content = "${file("${path.root}/shared/gdpr_recv.vcl")}"
-  }
-
-  snippet {
-    name    = "GDPR - Handle Redirect"
-    type    = "error"
-    content = "${file("${path.root}/shared/gdpr_error.vcl")}"
   }
 
   snippet {

--- a/dosomething-qa/fastly-backend/main.tf
+++ b/dosomething-qa/fastly-backend/main.tf
@@ -134,24 +134,6 @@ resource "fastly_service_v1" "backends-qa" {
   }
 
   snippet {
-    name    = "GDPR - Redirects Table"
-    type    = "init"
-    content = "${file("${path.root}/shared/gdpr_init.vcl")}"
-  }
-
-  snippet {
-    name    = "GDPR - Trigger Redirect"
-    type    = "recv"
-    content = "${file("${path.root}/shared/gdpr_recv.vcl")}"
-  }
-
-  snippet {
-    name    = "GDPR - Handle Redirect"
-    type    = "error"
-    content = "${file("${path.root}/shared/gdpr_error.vcl")}"
-  }
-
-  snippet {
     name    = "Shared - Set X-Origin-Name Header"
     type    = "fetch"
     content = "${file("${path.root}/shared/app_name.vcl")}"

--- a/dosomething-qa/fastly-frontend/main.tf
+++ b/dosomething-qa/fastly-frontend/main.tf
@@ -46,7 +46,7 @@ resource "fastly_service_v1" "frontend-qa" {
     type = "REQUEST"
     name = "is-authenticated"
 
-    # We want exclude logged-in users from Fastly caching (since their responses will 
+    # We want exclude logged-in users from Fastly caching (since their responses will
     # likely include user-specific content) but still cache static assets at the edge.
     statement = "req.http.Cookie ~ \"laravel_session=\" && req.url !~ \"\\.(css|js|woff|otf|ttf|svg)(\\?.*)?$\""
   }
@@ -157,24 +157,6 @@ resource "fastly_service_v1" "frontend-qa" {
     name    = "ProjectPages - Handle Redirect"
     type    = "error"
     content = "${file("${path.module}/legacy_redirects_error.vcl")}"
-  }
-
-  snippet {
-    name    = "GDPR - Redirects Table"
-    type    = "init"
-    content = "${file("${path.root}/shared/gdpr_init.vcl")}"
-  }
-
-  snippet {
-    name    = "GDPR - Trigger Redirect"
-    type    = "recv"
-    content = "${file("${path.root}/shared/gdpr_recv.vcl")}"
-  }
-
-  snippet {
-    name    = "GDPR - Handle Redirect"
-    type    = "error"
-    content = "${file("${path.root}/shared/gdpr_error.vcl")}"
   }
 
   snippet {

--- a/dosomething/fastly-backend/main.tf
+++ b/dosomething/fastly-backend/main.tf
@@ -162,24 +162,6 @@ resource "fastly_service_v1" "backends" {
   }
 
   snippet {
-    name    = "GDPR - Redirects Table"
-    type    = "init"
-    content = "${file("${path.root}/shared/gdpr_init.vcl")}"
-  }
-
-  snippet {
-    name    = "GDPR - Trigger Redirect"
-    type    = "recv"
-    content = "${file("${path.root}/shared/gdpr_recv.vcl")}"
-  }
-
-  snippet {
-    name    = "GDPR - Handle Redirect"
-    type    = "error"
-    content = "${file("${path.root}/shared/gdpr_error.vcl")}"
-  }
-
-  snippet {
     name    = "Shared - Set X-Origin-Name Header"
     type    = "fetch"
     content = "${file("${path.root}/shared/app_name.vcl")}"

--- a/dosomething/fastly-frontend/main.tf
+++ b/dosomething/fastly-frontend/main.tf
@@ -59,7 +59,7 @@ resource "fastly_service_v1" "frontend" {
     type = "REQUEST"
     name = "is-authenticated"
 
-    # We want exclude logged-in users from Fastly caching (since their responses will 
+    # We want exclude logged-in users from Fastly caching (since their responses will
     # likely include user-specific content) but still cache static assets at the edge.
     statement = "req.http.Cookie ~ \"laravel_session=\" && req.url !~ \"\\.(css|js|woff|otf|ttf|svg)(\\?.*)?$\""
   }
@@ -182,24 +182,6 @@ resource "fastly_service_v1" "frontend" {
     name    = "ProjectPages - Handle Redirect"
     type    = "error"
     content = "${file("${path.module}/legacy_redirects_error.vcl")}"
-  }
-
-  snippet {
-    name    = "GDPR - Redirects Table"
-    type    = "init"
-    content = "${file("${path.root}/shared/gdpr_init.vcl")}"
-  }
-
-  snippet {
-    name    = "GDPR - Trigger Redirect"
-    type    = "recv"
-    content = "${file("${path.root}/shared/gdpr_recv.vcl")}"
-  }
-
-  snippet {
-    name    = "GDPR - Handle Redirect"
-    type    = "error"
-    content = "${file("${path.root}/shared/gdpr_error.vcl")}"
   }
 
   snippet {


### PR DESCRIPTION
These changes remove the country-specific redirect logic from Fastly. Starting in May 2018, we redirected all traffic from GDPR-affected countries to our ["Sorry, you can't see anything" page](https://sorry.dosomething.org/), promising to open back up as soon as we were able.

Now that we're ready for this traffic, we'll remove these exceptions from our dev, QA, and prod Fastly properties.

IN PROCESS: This PR only includes dev and QA Fastly changes.