### PR TITLE
Update Fastly provider for Terraform 0.12 support.

### DIFF
--- a/main.tf
+++ b/main.tf
@@ -37,7 +37,7 @@ terraform {
 # in front of (most of) our services & handles caching,
 # backend-routing, geolocation, redirects, etc.
 provider "fastly" {
-  version = "~> 0.6"
+  version = "~> 0.8"
   api_key = "${var.fastly_api_key}"
 }
 


### PR DESCRIPTION
This pull request updates the Fastly provider to [v0.8.0](https://github.com/terraform-providers/terraform-provider-fastly/blob/master/CHANGELOG.md#080-june-28-2019), which includes support for Terraform 0.12.

And with that, we should be good to go...! 🚀 

```
$ terraform 0.12checklist

Looks good! We did not detect any problems that ought to be
addressed before upgrading to Terraform v0.12.
```


References [#166288730](https://www.pivotaltracker.com/story/show/166288730)