### PR TITLE
Updating Quasar Postgres version to 11.4 for security patching.

### DIFF
--- a/quasar/main.tf
+++ b/quasar/main.tf
@@ -523,7 +523,7 @@ data "aws_ssm_parameter" "prod_password" {
 resource "aws_db_instance" "quasar-qa" {
   allocated_storage               = 1000
   engine                          = "postgres"
-  engine_version                  = "11.2"
+  engine_version                  = "11.4"
   instance_class                  = "db.m5.2xlarge"
   allow_major_version_upgrade     = true
   name                            = "quasar"
@@ -543,7 +543,7 @@ resource "aws_db_instance" "quasar-qa" {
 resource "aws_db_instance" "quasar" {
   allocated_storage               = 4000
   engine                          = "postgres"
-  engine_version                  = "11.2"
+  engine_version                  = "11.4"
   instance_class                  = "db.m5.4xlarge"
   name                            = "quasar_prod_warehouse"
   username                        = "${data.aws_ssm_parameter.prod_username.value}"


### PR DESCRIPTION
Upgrades Quasar Postgres version to 11.4 for [security reasons](https://docs.aws.amazon.com/AmazonRDS/latest/UserGuide/CHAP_PostgreSQL.html#PostgreSQL.Concepts.General.version114).

Output of `make plan`:
```
~ module.quasar.aws_db_instance.quasar
    engine_version:   "11.2" => "11.4"

~ module.quasar.aws_db_instance.quasar-qa
    engine_version:   "11.2" => "11.4"

Plan: 0 to add, 2 to change, 0 to destroy.
```

Should apply automatically on Sunday downtime period. 