### PR TITLE
Adding certificate creation for AWS VPN for Quasar.

### DIFF
--- a/quasar/main.tf
+++ b/quasar/main.tf
@@ -476,3 +476,11 @@ resource "aws_db_instance" "quasar" {
   enabled_cloudwatch_logs_exports = ["postgresql", "upgrade"]
 }
 
+resource "aws_acm_certificate" "cert" {
+  domain_name       = "vpn.d12g.co"
+  validation_method = "EMAIL"
+}
+
+resource "aws_acm_certificate_validation" "cert" {
+  certificate_arn = "${aws_acm_certificate.cert.arn}"
+}


### PR DESCRIPTION
* [This](https://github.com/DoSomething/infrastructure/compare/aws-vpn?expand=1#diff-9c2578982d1e7190ae7d08c9f7b03e61) adds a request to Amazon Certificate Manager to provision an email verified cert as the first step in [setting up](https://www.pivotaltracker.com/story/show/168177529) the AWS Client VPN testing.
* The `api_gateway` component file had some syntax errors the githook was complaining about before I committed, so included that update as well.