### PR TITLE
Adding secure password generator and Microsoft AD domain setup for VPN.

### DIFF
--- a/quasar/main.tf
+++ b/quasar/main.tf
@@ -475,3 +475,28 @@ resource "aws_db_instance" "quasar" {
   performance_insights_enabled    = true
   enabled_cloudwatch_logs_exports = ["postgresql", "upgrade"]
 }
+
+resource "random_string" "admin_password" {
+  # Adding to generate secure password for VPN AD Domain.
+  length = 24
+
+  # We can't use '@' or '$' in MySQL passwords.
+  override_special = "!#%&*()-_=+[]{}<>:?"
+}
+
+
+data "aws_acm_certificate" "vpn-cert" {
+  domain = "vpn.d12g.co"
+}
+
+resource "aws_directory_service_directory" "vpn-ad" {
+  name     = "ad.d12g.co"
+  password = random_string.admin_password.result
+  edition  = "Standard"
+  type     = "MicrosoftAD"
+
+  vpc_settings {
+    vpc_id     = "${aws_vpc.vpc.id}"
+    subnet_ids = ["${aws_subnet.subnet-a.id}", "${aws_subnet.subnet-b.id}"]
+  }
+}

--- a/quasar/main.tf
+++ b/quasar/main.tf
@@ -478,10 +478,8 @@ resource "aws_db_instance" "quasar" {
 
 resource "random_string" "admin_password" {
   # Adding to generate secure password for VPN AD Domain.
-  length = 24
-
-  # We can't use '@' or '$' in MySQL passwords.
-  override_special = "!#%&*()-_=+[]{}<>:?"
+  length  = 24
+  special = false
 }
 
 


### PR DESCRIPTION
This PR accomplishes the following:
* Adds data resource for generated ACM certificate that was manually provisioned from AWS Console. Currently not used for anything, merely here for future building blocks.
* Adds random password generator with [code we already use](https://github.com/DoSomething/infrastructure/blob/master/components/mariadb_instance/main.tf#L95-L100) for the MariaDB master password generator. This is used to set strong admin password for Active Directory service.
* Sets up standard AWS Active Directory service for use with AWS Client VPN.