### PR TITLE
Updating to internal DNS entry so resolveable from within VPC.

### DIFF
--- a/quasar/main.tf
+++ b/quasar/main.tf
@@ -488,7 +488,7 @@ data "aws_acm_certificate" "vpn-cert" {
 }
 
 resource "aws_directory_service_directory" "vpn-ad" {
-  name     = "ad.d12g.co"
+  name     = "ad.ds.internal"
   password = random_string.admin_password.result
   edition  = "Standard"
   type     = "MicrosoftAD"


### PR DESCRIPTION
Have to update (or in this case, it's actually a destroy/create paradigm) the Directory Service to a different DNS name that resolves internally on VPC instances only, since d12g.co is referred to DNS made easy, and the backend DNS entries might change, and we want AWS to manage those.