### PR TITLE
Set ISO-3166 region & zip-code headers via Fastly.

### DIFF
--- a/dosomething-dev/fastly-frontend/main.tf
+++ b/dosomething-dev/fastly-frontend/main.tf
@@ -5,8 +5,10 @@ variable "papertrail_log_format" {}
 
 locals {
   headers = {
-    "X-Fastly-Country-Code" = "client.geo.country_code",
-    "X-Fastly-Region-Code"  = "client.geo.region",
+    "X-Fastly-Country-Code"  = "client.geo.country_code",
+    "X-Fastly-Region-Code"   = "client.geo.region",
+    "X-Fastly-Location-Code" = "client.geo.region.ascii",
+    "X-Fastly-Postal-Code"   = "client.geo.postal_code",
   }
 }
 

--- a/dosomething-dev/fastly-frontend/main.tf
+++ b/dosomething-dev/fastly-frontend/main.tf
@@ -74,12 +74,12 @@ resource "fastly_service_v1" "frontend-dev" {
     ]
   }
 
-  // Set headers on incoming HTTP requests, for the backend server.
+  # Set headers on incoming HTTP requests, for the backend server.
   dynamic "header" {
     for_each = local.headers
 
     content {
-      name        = header.key
+      name        = "${header.key} (Request)"
       destination = "http.${header.key}"
       source      = header.value
       type        = "request"
@@ -87,12 +87,12 @@ resource "fastly_service_v1" "frontend-dev" {
     }
   }
 
-  // And set "debug" headers on HTTP responses, for inspection.
+  # And set "debug" headers on HTTP responses, for inspection.
   dynamic "header" {
     for_each = local.headers
 
     content {
-      name        = "${header.key} (Debug)"
+      name        = "${header.key} (Response)"
       destination = "http.${header.key}"
       source      = header.value
       type        = "response"

--- a/dosomething-dev/fastly-frontend/main.tf
+++ b/dosomething-dev/fastly-frontend/main.tf
@@ -5,10 +5,9 @@ variable "papertrail_log_format" {}
 
 locals {
   headers = {
-    "X-Fastly-Country-Code"  = "client.geo.country_code",
-    "X-Fastly-Region-Code"   = "client.geo.region",
-    "X-Fastly-Location-Code" = "client.geo.region.ascii",
-    "X-Fastly-Postal-Code"   = "client.geo.postal_code",
+    "X-Fastly-Country-Code" = "client.geo.country_code",
+    "X-Fastly-Region-Code"  = "client.geo.region",
+    "X-Fastly-Postal-Code"  = "client.geo.postal_code",
   }
 }
 

--- a/dosomething-dev/fastly-frontend/main.tf
+++ b/dosomething-dev/fastly-frontend/main.tf
@@ -3,6 +3,13 @@ variable "phoenix_backend" {}
 variable "papertrail_destination" {}
 variable "papertrail_log_format" {}
 
+locals {
+  headers = {
+    "X-Fastly-Country-Code" = "client.geo.country_code",
+    "X-Fastly-Region-Code"  = "client.geo.region",
+  }
+}
+
 resource "fastly_service_v1" "frontend-dev" {
   name          = "Terraform: Frontend (Development)"
   force_destroy = true
@@ -66,36 +73,30 @@ resource "fastly_service_v1" "frontend-dev" {
     ]
   }
 
-  header {
-    name        = "Country Code"
-    type        = "request"
-    action      = "set"
-    source      = "geoip.country_code"
-    destination = "http.X-Fastly-Country-Code"
+  // Set headers on incoming HTTP requests, for the backend server.
+  dynamic "header" {
+    for_each = local.headers
+
+    content {
+      name        = header.key
+      destination = "http.${header.key}"
+      source      = header.value
+      type        = "request"
+      action      = "set"
+    }
   }
 
-  header {
-    name        = "Country Code (Debug)"
-    type        = "response"
-    action      = "set"
-    source      = "geoip.country_code"
-    destination = "http.X-Fastly-Country-Code"
-  }
+  // And set "debug" headers on HTTP responses, for inspection.
+  dynamic "header" {
+    for_each = local.headers
 
-  header {
-    name        = "Region Code"
-    type        = "request"
-    action      = "set"
-    source      = "client.geo.region"
-    destination = "http.X-Fastly-Region-Code"
-  }
-
-  header {
-    name        = "Region Code (Debug)"
-    type        = "response"
-    action      = "set"
-    source      = "client.geo.region"
-    destination = "http.X-Fastly-Region-Code"
+    content {
+      name        = "${header.key} (Debug)"
+      destination = "http.${header.key}"
+      source      = header.value
+      type        = "response"
+      action      = "set"
+    }
   }
 
   request_setting {

--- a/dosomething-qa/fastly-frontend/main.tf
+++ b/dosomething-qa/fastly-frontend/main.tf
@@ -5,8 +5,10 @@ variable "papertrail_log_format" {}
 
 locals {
   headers = {
-    "X-Fastly-Country-Code" = "client.geo.country_code",
-    "X-Fastly-Region-Code"  = "client.geo.region",
+    "X-Fastly-Country-Code"  = "client.geo.country_code",
+    "X-Fastly-Region-Code"   = "client.geo.region",
+    "X-Fastly-Location-Code" = "client.geo.region.ascii",
+    "X-Fastly-Postal-Code"   = "client.geo.postal_code",
   }
 }
 

--- a/dosomething-qa/fastly-frontend/main.tf
+++ b/dosomething-qa/fastly-frontend/main.tf
@@ -92,12 +92,12 @@ resource "fastly_service_v1" "frontend-qa" {
     ]
   }
 
-  // Set headers on incoming HTTP requests, for the backend server.
+  # Set headers on incoming HTTP requests, for the backend server.
   dynamic "header" {
     for_each = local.headers
 
     content {
-      name        = header.key
+      name        = "${header.key} (Request)"
       destination = "http.${header.key}"
       source      = header.value
       type        = "request"
@@ -105,12 +105,12 @@ resource "fastly_service_v1" "frontend-qa" {
     }
   }
 
-  // And set "debug" headers on HTTP responses, for inspection.
+  # And set "debug" headers on HTTP responses, for inspection.
   dynamic "header" {
     for_each = local.headers
 
     content {
-      name        = "${header.key} (Debug)"
+      name        = "${header.key} (Response)"
       destination = "http.${header.key}"
       source      = header.value
       type        = "response"

--- a/dosomething-qa/fastly-frontend/main.tf
+++ b/dosomething-qa/fastly-frontend/main.tf
@@ -5,10 +5,9 @@ variable "papertrail_log_format" {}
 
 locals {
   headers = {
-    "X-Fastly-Country-Code"  = "client.geo.country_code",
-    "X-Fastly-Region-Code"   = "client.geo.region",
-    "X-Fastly-Location-Code" = "client.geo.region.ascii",
-    "X-Fastly-Postal-Code"   = "client.geo.postal_code",
+    "X-Fastly-Country-Code" = "client.geo.country_code",
+    "X-Fastly-Region-Code"  = "client.geo.region",
+    "X-Fastly-Postal-Code"  = "client.geo.postal_code",
   }
 }
 

--- a/dosomething-qa/fastly-frontend/main.tf
+++ b/dosomething-qa/fastly-frontend/main.tf
@@ -3,6 +3,13 @@ variable "phoenix_backend" {}
 variable "papertrail_destination" {}
 variable "papertrail_log_format" {}
 
+locals {
+  headers = {
+    "X-Fastly-Country-Code" = "client.geo.country_code",
+    "X-Fastly-Region-Code"  = "client.geo.region",
+  }
+}
+
 resource "fastly_service_v1" "frontend-qa" {
   name          = "Terraform: Frontend (QA)"
   force_destroy = true
@@ -84,36 +91,30 @@ resource "fastly_service_v1" "frontend-qa" {
     ]
   }
 
-  header {
-    name        = "Country Code"
-    type        = "request"
-    action      = "set"
-    source      = "geoip.country_code"
-    destination = "http.X-Fastly-Country-Code"
+  // Set headers on incoming HTTP requests, for the backend server.
+  dynamic "header" {
+    for_each = local.headers
+
+    content {
+      name        = header.key
+      destination = "http.${header.key}"
+      source      = header.value
+      type        = "request"
+      action      = "set"
+    }
   }
 
-  header {
-    name        = "Country Code (Debug)"
-    type        = "response"
-    action      = "set"
-    source      = "geoip.country_code"
-    destination = "http.X-Fastly-Country-Code"
-  }
+  // And set "debug" headers on HTTP responses, for inspection.
+  dynamic "header" {
+    for_each = local.headers
 
-  header {
-    name        = "Region Code"
-    type        = "request"
-    action      = "set"
-    source      = "client.geo.region"
-    destination = "http.X-Fastly-Region-Code"
-  }
-
-  header {
-    name        = "Region Code (Debug)"
-    type        = "response"
-    action      = "set"
-    source      = "client.geo.region"
-    destination = "http.X-Fastly-Region-Code"
+    content {
+      name        = "${header.key} (Debug)"
+      destination = "http.${header.key}"
+      source      = header.value
+      type        = "response"
+      action      = "set"
+    }
   }
 
   request_setting {

--- a/dosomething/fastly-frontend/main.tf
+++ b/dosomething/fastly-frontend/main.tf
@@ -5,6 +5,14 @@ variable "phoenix_backend" {}
 variable "papertrail_destination" {}
 variable "papertrail_log_format" {}
 
+locals {
+  headers = {
+    "X-Fastly-Country-Code" = "client.geo.country_code",
+    "X-Fastly-Region-Code"  = "client.geo.region",
+    "X-Fastly-Postal-Code"  = "client.geo.postal_code",
+  }
+}
+
 resource "fastly_service_v1" "frontend" {
   name          = "Terraform: Frontend"
   force_destroy = true
@@ -109,36 +117,30 @@ resource "fastly_service_v1" "frontend" {
     source          = "\"Origin, Access-Control-Request-Headers, Access-Control-Request-Method\""
   }
 
-  header {
-    name        = "Country Code"
-    type        = "request"
-    action      = "set"
-    source      = "geoip.country_code"
-    destination = "http.X-Fastly-Country-Code"
+  # Set headers on incoming HTTP requests, for the backend server.
+  dynamic "header" {
+    for_each = local.headers
+
+    content {
+      name        = "${header.key} (Request)"
+      destination = "http.${header.key}"
+      source      = header.value
+      type        = "request"
+      action      = "set"
+    }
   }
 
-  header {
-    name        = "Country Code (Debug)"
-    type        = "response"
-    action      = "set"
-    source      = "geoip.country_code"
-    destination = "http.X-Fastly-Country-Code"
-  }
+  # And set "debug" headers on HTTP responses, for inspection.
+  dynamic "header" {
+    for_each = local.headers
 
-  header {
-    name        = "Region Code"
-    type        = "request"
-    action      = "set"
-    source      = "client.geo.region"
-    destination = "http.X-Fastly-Region-Code"
-  }
-
-  header {
-    name        = "Region Code (Debug)"
-    type        = "response"
-    action      = "set"
-    source      = "client.geo.region"
-    destination = "http.X-Fastly-Region-Code"
+    content {
+      name        = "${header.key} (Response)"
+      destination = "http.${header.key}"
+      source      = header.value
+      type        = "response"
+      action      = "set"
+    }
   }
 
   request_setting {

--- a/quasar/main.tf
+++ b/quasar/main.tf
@@ -475,8 +475,3 @@ resource "aws_db_instance" "quasar" {
   performance_insights_enabled    = true
   enabled_cloudwatch_logs_exports = ["postgresql", "upgrade"]
 }
-
-data "aws_acm_certificate" "vpn-cert" {
-  domain = "vpn.d12g.co"
-}
-


### PR DESCRIPTION
This pull request updates our Fastly properties to dynamically create request & response header rules based on a dictionary mapping (using [dynamic blocks](https://www.terraform.io/docs/configuration/expressions.html#dynamic-blocks)), and adds the new zip-code header that we need for [#168320231](https://www.pivotaltracker.com/story/show/168320231).