### PR TITLE
Add 'X-Fastly-Location-Code' header with full ISO-3166-2 code.

### DIFF
--- a/dosomething-dev/fastly-frontend/main.tf
+++ b/dosomething-dev/fastly-frontend/main.tf
@@ -112,6 +112,18 @@ resource "fastly_service_v1" "frontend-dev" {
   }
 
   snippet {
+    name    = "Frontend - ISO-3166-2 Request Header"
+    type    = "recv"
+    content = file("${path.module}/iso3166_recv.vcl")
+  }
+
+  snippet {
+    name    = "Frontend - ISO-3166-2 Response Header"
+    type    = "deliver"
+    content = file("${path.module}/iso3166_deliver.vcl")
+  }
+
+  snippet {
     name    = "Frontend - Trigger International Redirect"
     type    = "recv"
     content = file("${path.module}/homepage_recv.vcl")
@@ -154,6 +166,7 @@ resource "fastly_service_v1" "frontend-dev" {
     type    = "fetch"
     content = file("${path.root}/shared/app_name.vcl")
   }
+
 
   papertrail {
     name    = "frontend"

--- a/dosomething-dev/fastly-frontend/main.tf
+++ b/dosomething-dev/fastly-frontend/main.tf
@@ -114,13 +114,13 @@ resource "fastly_service_v1" "frontend-dev" {
   snippet {
     name    = "Frontend - ISO-3166-2 Request Header"
     type    = "recv"
-    content = file("${path.module}/iso3166_recv.vcl")
+    content = file("${path.root}/shared/iso3166_recv.vcl")
   }
 
   snippet {
     name    = "Frontend - ISO-3166-2 Response Header"
     type    = "deliver"
-    content = file("${path.module}/iso3166_deliver.vcl")
+    content = file("${path.root}/shared/iso3166_deliver.vcl")
   }
 
   snippet {

--- a/dosomething-qa/fastly-frontend/main.tf
+++ b/dosomething-qa/fastly-frontend/main.tf
@@ -124,6 +124,18 @@ resource "fastly_service_v1" "frontend-qa" {
   }
 
   snippet {
+    name    = "Frontend - ISO-3166-2 Request Header"
+    type    = "recv"
+    content = file("${path.module}/iso3166_recv.vcl")
+  }
+
+  snippet {
+    name    = "Frontend - ISO-3166-2 Response Header"
+    type    = "deliver"
+    content = file("${path.module}/iso3166_deliver.vcl")
+  }
+
+  snippet {
     name    = "Frontend - Trigger International Redirect"
     type    = "recv"
     content = file("${path.module}/homepage_recv.vcl")

--- a/dosomething-qa/fastly-frontend/main.tf
+++ b/dosomething-qa/fastly-frontend/main.tf
@@ -126,13 +126,13 @@ resource "fastly_service_v1" "frontend-qa" {
   snippet {
     name    = "Frontend - ISO-3166-2 Request Header"
     type    = "recv"
-    content = file("${path.module}/iso3166_recv.vcl")
+    content = file("${path.root}/shared/iso3166_recv.vcl")
   }
 
   snippet {
     name    = "Frontend - ISO-3166-2 Response Header"
     type    = "deliver"
-    content = file("${path.module}/iso3166_deliver.vcl")
+    content = file("${path.root}/shared/iso3166_deliver.vcl")
   }
 
   snippet {

--- a/dosomething/fastly-frontend/main.tf
+++ b/dosomething/fastly-frontend/main.tf
@@ -149,6 +149,18 @@ resource "fastly_service_v1" "frontend" {
   }
 
   snippet {
+    name    = "Frontend - ISO-3166-2 Request Header"
+    type    = "recv"
+    content = file("${path.root}/shared/iso3166_recv.vcl")
+  }
+
+  snippet {
+    name    = "Frontend - ISO-3166-2 Response Header"
+    type    = "deliver"
+    content = file("${path.root}/shared/iso3166_deliver.vcl")
+  }
+
+  snippet {
     name    = "Frontend - Trigger International Redirect"
     type    = "recv"
     content = file("${path.module}/homepage_recv.vcl")

--- a/shared/iso3166_deliver.vcl
+++ b/shared/iso3166_deliver.vcl
@@ -1,0 +1,11 @@
+// Are were able to determine a country code? (If not, value is "**"):
+if (client.geo.country_code != "**") {
+  // US Territories should be stored as regions under 'US-'. <https://goo.gl/qzcMyb>
+  if (client.geo.country_code ~ "AS|GU|MP|PR|UM|VI") {
+    set resp.http.X-Fastly-Location-Code = "US-" + client.geo.country_code;
+  }
+  // Otherwise, were we able to determine a region? (If not, value is "NO REGION" or "?"):
+  else if (client.geo.region != "NO REGION" && client.geo.region != "?") {
+    set resp.http.X-Fastly-Location-Code = client.geo.country_code + "-" + client.geo.region;
+  }
+}

--- a/shared/iso3166_recv.vcl
+++ b/shared/iso3166_recv.vcl
@@ -1,0 +1,11 @@
+// Are were able to determine a country code? (If not, value is "**"):
+if (client.geo.country_code != "**") {
+  // US Territories should be stored as regions under 'US-'. <https://goo.gl/qzcMyb>
+  if (client.geo.country_code ~ "AS|GU|MP|PR|UM|VI") {
+    set req.http.X-Fastly-Location-Code = "US-" + client.geo.country_code;
+  }
+  // Otherwise, were we able to determine a region? (If not, value is "NO REGION" or "?"):
+  else if (client.geo.region != "NO REGION" && client.geo.region != "?") {
+    set req.http.X-Fastly-Location-Code = client.geo.country_code + "-" + client.geo.region;
+  }
+}


### PR DESCRIPTION
This pull request adds a `X-Fastly-Location-Code` header with the full [ISO-3166-2](https://en.wikipedia.org/wiki/ISO_3166-2) code for the geolocated request. This removes [some extra work we do within our application code](https://github.com/DoSomething/phoenix-next/blob/3f9d7680de49eb329ee7f7e6ddb658ffdffdca8b/app/Providers/AppServiceProvider.php#L58-L74) & hopefully reduces the chance we get bad values here.

Here's a [Fastly Fiddle](https://fiddle.fastlydemo.net/fiddle/3c40c3d8) demonstrating the custom snippets introduced in the request. For testing, you can use the `Custom-IP-Override` header to test how Fastly would handle different IP addresses.

References [#168387140](https://www.pivotaltracker.com/story/show/168387140) and [#168320231](https://www.pivotaltracker.com/story/show/168320231).
