### PR TITLE
Adding terraform module to test adhoc SSH bastion hosts in Quasar VPC.

### DIFF
--- a/quasar/main.tf
+++ b/quasar/main.tf
@@ -475,3 +475,12 @@ resource "aws_db_instance" "quasar" {
   performance_insights_enabled    = true
   enabled_cloudwatch_logs_exports = ["postgresql", "upgrade"]
 }
+
+# Testing Bastion SSH dynamic runtime
+module "ssh-bastion-service" {
+  source      = "joshuamkite/ssh-bastion-service/aws"
+  version     = "5.0.0"
+  aws_profile = ""
+  aws_region  = "us-east-1"
+  vpc         = aws_vpc.vpc.id
+}


### PR DESCRIPTION
Testing out Terraform module that creates dockerized adhoc SSH bastion hosts from SSH keys stored on an IAM profile that [Dave found](https://www.pivotaltracker.com/story/show/168177529/comments/206165384). 

