### PR TITLE
Updated AWS provider to version 2.28 in prep for AWS VPN config.

### DIFF
--- a/main.tf
+++ b/main.tf
@@ -57,7 +57,7 @@ provider "heroku" {
 # some legacy servers on EC2. AWS credentials are stored
 # using the `aws` CLI (see installation instructions).
 provider "aws" {
-  version = "~> 2.15"
+  version = "~> 2.28"
   region  = "us-east-1"
   profile = "terraform"
 }


### PR DESCRIPTION
Updates AWS Provider to version `2.28`, since Quasar AWS VPN setup needs to be set with `split-tunnel` config which was [released](https://github.com/terraform-providers/terraform-provider-aws/blob/master/CHANGELOG.md#2220-august-01-2019) in version `2.20`.