### PR TITLE
Always return 302 for Aurora redirects.

### DIFF
--- a/dosomething-dev/fastly-frontend/redirect_error.vcl
+++ b/dosomething-dev/fastly-frontend/redirect_error.vcl
@@ -9,7 +9,7 @@ if (obj.status == 777) {
   }
 
   set obj.http.Location = var.new_location;
-  set obj.status = std.atoi(table.lookup(redirect_types, req.url, "302"));
+  set obj.status = 302;
 
   return(deliver);
 }

--- a/dosomething-qa/fastly-frontend/redirect_error.vcl
+++ b/dosomething-qa/fastly-frontend/redirect_error.vcl
@@ -9,7 +9,7 @@ if (obj.status == 777) {
   }
 
   set obj.http.Location = var.new_location;
-  set obj.status = std.atoi(table.lookup(redirect_types, req.url, "302"));
+  set obj.status = 302;
 
   return(deliver);
 }

--- a/dosomething/fastly-frontend/redirect_error.vcl
+++ b/dosomething/fastly-frontend/redirect_error.vcl
@@ -9,7 +9,7 @@ if (obj.status == 777) {
   }
 
   set obj.http.Location = var.new_location;
-  set obj.status = std.atoi(table.lookup(redirect_types, req.url, "302"));
+  set obj.status = 302;
 
   return(deliver);
 }


### PR DESCRIPTION
This pull request updates our "redirect" snippets to always use `302 Found`, rather than reading from the `redirect_types` table (which let admins choose `301 Moved Permanently` or `302 Found`). This reduces the chance of accidentally creating a "permanent" redirect that we don't _really_ want.

References [#168057201](https://www.pivotaltracker.com/story/show/168057201)