### PR TITLE
Remove unused 'redirect_types' dictionary.

### DIFF
--- a/dosomething-dev/fastly-frontend/main.tf
+++ b/dosomething-dev/fastly-frontend/main.tf
@@ -177,9 +177,5 @@ resource "fastly_service_v1" "frontend-dev" {
   dictionary {
     name = "redirects"
   }
-
-  dictionary {
-    name = "redirect_types"
-  }
 }
 

--- a/dosomething-qa/fastly-frontend/main.tf
+++ b/dosomething-qa/fastly-frontend/main.tf
@@ -203,9 +203,5 @@ resource "fastly_service_v1" "frontend-qa" {
   dictionary {
     name = "redirects"
   }
-
-  dictionary {
-    name = "redirect_types"
-  }
 }
 

--- a/dosomething/fastly-frontend/main.tf
+++ b/dosomething/fastly-frontend/main.tf
@@ -228,9 +228,5 @@ resource "fastly_service_v1" "frontend" {
   dictionary {
     name = "redirects"
   }
-
-  dictionary {
-    name = "redirect_types"
-  }
 }
 


### PR DESCRIPTION
This pull request removes the now unused `redirect_types` dictionary. We stopped using this in our VCL in #211, and Aurora stopped reading or writing to it in DoSomething/aurora#227.

References [#168057201](https://www.pivotaltracker.com/story/show/168057201).