### PR TITLE
Change default non-production scale for Phoenix.

### DIFF
--- a/applications/phoenix/main.tf
+++ b/applications/phoenix/main.tf
@@ -94,7 +94,7 @@ module "app" {
 
   web_size = coalesce(
     var.web_size,
-    var.environment == "production" ? "Performance-M" : "Hobby",
+    var.environment == "production" ? "Performance-M" : "Standard-1X",
   )
 
   queue_scale = 0


### PR DESCRIPTION
This changes the default scale for Phoenix's non-prod environments to `Standard-1X`, rather than `Hobby`. (It seems like we've made this change by hand, but this will keep it from reverting).