### PR TITLE
Use 'templatefile' helper to avoid rebuilding IAM policies.

### DIFF
--- a/components/lambda_function/main.tf
+++ b/components/lambda_function/main.tf
@@ -112,17 +112,11 @@ resource "aws_iam_user" "lambda_deploy" {
 }
 
 resource "aws_iam_user_policy" "deploy_policy" {
-  user   = aws_iam_user.lambda_deploy.name
-  policy = data.template_file.deploy_policy.rendered
-}
-
-data "template_file" "deploy_policy" {
-  template = file("${path.module}/deploy-policy.json.tpl")
-
-  vars = {
+  user = aws_iam_user.lambda_deploy.name
+  policy = templatefile("${path.module}/deploy-policy.json.tpl", {
     deploy_bucket_arn   = aws_s3_bucket.deploy.arn
     lambda_function_arn = aws_lambda_function.function.arn
-  }
+  })
 }
 
 resource "aws_iam_access_key" "deploy_key" {


### PR DESCRIPTION
This pull request replaces this [`template_file`](https://www.terraform.io/docs/providers/template/d/file.html) data resource with Terraform 0.12's [`templatefile`](https://www.terraform.io/docs/configuration/functions/templatefile.html) helper function. This fixes an issue where these policies would incorrectly show as "changed" when we planned out changes.