### PR TITLE
Upping Quasar QA storage since it ran out.

### DIFF
--- a/quasar/main.tf
+++ b/quasar/main.tf
@@ -445,7 +445,7 @@ data "aws_ssm_parameter" "prod_password" {
 }
 
 resource "aws_db_instance" "quasar-qa" {
-  allocated_storage               = 1000
+  allocated_storage               = 4000
   engine                          = "postgres"
   engine_version                  = "11.4"
   instance_class                  = "db.m5.2xlarge"


### PR DESCRIPTION
### What's this PR do?

We ran out of storage space on Quasar QA while attempting a [refresh from Prod](https://www.pivotaltracker.com/story/show/164447976). Upping the storage to match Production values.

### How should this be reviewed?

We'll see if it can upgrade the storage while in `storage-full` status. No other troubleshooting has been successful since we can't even connect to the server. 

### Any background context you want to provide?

...

### Relevant tickets

References [Pivotal #170705217](https://www.pivotaltracker.com/story/show/170705217).

### Checklist

- [x] This PR has been added to the relevant Pivotal card.
