### PR TITLE
Allow Rogue to be deleted(!).

### DIFF
--- a/applications/rogue/main.tf
+++ b/applications/rogue/main.tf
@@ -41,6 +41,11 @@ variable "backup_storage_bucket" {
   default     = null
 }
 
+variable "deprecated" {
+  description = "Deprecate this app, removing database users & allowing deletion."
+  default     = false
+}
+
 variable "with_newrelic" {
   # See usage below for default fallback. <https://stackoverflow.com/a/51758050/811624>
   description = "Should New Relic be enabled for this app? Enabled by default on prod."
@@ -96,6 +101,7 @@ module "database" {
   instance_class = var.environment == "production" ? "db.m4.large" : "db.t2.medium"
   multi_az       = var.environment == "production"
   is_dms_source  = true
+  deprecated     = var.deprecated
 }
 
 module "iam_user" {

--- a/dosomething-qa/main.tf
+++ b/dosomething-qa/main.tf
@@ -76,6 +76,7 @@ module "rogue" {
   domain                 = "activity-qa.dosomething.org"
   pipeline               = var.rogue_pipeline
   papertrail_destination = var.papertrail_destination
+  deprecated             = true
 }
 
 module "papertrail" {


### PR DESCRIPTION
### What's this PR do?

This pull request adds a `deprecated` flag to the Rogue application module, allowing us to remove MySQL users/provider before deleting the whole app. This should address [this issue](https://dosomething.slack.com/archives/CSRFBK51T/p1579191649002500) we ran into when starting our fire drill.

### How should this be reviewed?

Am I deleting the right app's users? 🙈

### Any background context you want to provide?

👨‍🚒

### Relevant tickets

References [Pivotal #170080527](https://www.pivotaltracker.com/story/show/170080527).

### Checklist

- [ ] This PR has been added to the relevant Pivotal card.
