### PR TITLE
Delete Rogue QA for fire drill.

### DIFF
--- a/dosomething-qa/main.tf
+++ b/dosomething-qa/main.tf
@@ -31,9 +31,9 @@ module "fastly-backend" {
   northstar_domain  = module.northstar.domain
   northstar_backend = module.northstar.backend
 
-  rogue_name    = module.rogue.name
-  rogue_domain  = module.rogue.domain
-  rogue_backend = module.rogue.backend
+  rogue_name    = "dosomething-rogue-qa"
+  rogue_domain  = "activity-qa.dosomething.org"
+  rogue_backend = "dosomething-rogue-qa.herokuapp.com"
 
   papertrail_destination = var.papertrail_destination_fastly
   papertrail_log_format  = local.papertrail_log_format
@@ -68,15 +68,21 @@ module "phoenix" {
   papertrail_destination = var.papertrail_destination
 }
 
-module "rogue" {
-  source = "../applications/rogue"
+# module "rogue" {
+#   source = "../applications/rogue"
 
-  environment            = "qa"
-  name                   = "dosomething-rogue-qa"
-  domain                 = "activity-qa.dosomething.org"
-  pipeline               = var.rogue_pipeline
-  papertrail_destination = var.papertrail_destination
-  deprecated             = true
+#   environment            = "qa"
+#   name                   = "dosomething-rogue-qa"
+#   domain                 = "activity-qa.dosomething.org"
+#   pipeline               = var.rogue_pipeline
+#   papertrail_destination = var.papertrail_destination
+#   deprecated             = true
+# }
+
+module "rogue_storage" {
+  source = "../components/s3_bucket"
+
+  name = "dosomething-rogue-qa"
 }
 
 module "papertrail" {


### PR DESCRIPTION
### What's this PR do?

This pull request deletes Rogue QA (Heroku app, SQS queue, IAM user, RDS database) so that we can test rebuilding it from scratch. We've `terraform state mv`'d the S3 bucket aside, since AWS won't let us delete it until the bucket is empty and that'd be a real slog.

### How should this be reviewed?

👀

### Any background context you want to provide?

🔥 

### Relevant tickets

References [Pivotal #170080527](https://www.pivotaltracker.com/story/show/170080527).

### Checklist

- [ ] This PR has been added to the relevant Pivotal card.
