### PR TITLE
Add 'final_snapshot_identifier' to MariaDB instances.

### DIFF
--- a/components/mariadb_instance/main.tf
+++ b/components/mariadb_instance/main.tf
@@ -133,6 +133,8 @@ resource "aws_db_instance" "database" {
 
   deletion_protection = false == var.deprecated
 
+  final_snapshot_identifier = "final-snapshot-${var.name}"
+
   tags = {
     Application = var.name
   }


### PR DESCRIPTION
### What's this PR do?

This pull request adds `final_snapshot_identifier` to our databases so we can make a final snapshot if we delete any of them.

### How should this be reviewed?

👀

### Any background context you want to provide?

🔥 

### Relevant tickets

References [Pivotal #170080527](https://www.pivotaltracker.com/story/show/170080527).

### Checklist

- [ ] This PR has been added to the relevant Pivotal card.
