### PR TITLE
Update documentation based on fire-drill notes.

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -17,24 +17,4 @@ format: ## Format your code automatically.
 	@terraform fmt
 
 plan: ## See how your changes would affect our infrastructure if applied.
-	@echo "Re-initializing Terraform & planning your change..."
-	@# First, quickly re-initialize for new modules or plugins.
-	@terraform init --backend=false
-	@# We use Landscape to make the diff easier to read.
 	@terraform plan
-
-
-apply: ## Update infrastructure to match your Terraform config.
-	@if [ -n "$$(git status --porcelain)" ]; then \
-		echo "$(BOLD)$(RED)✘ERROR: Commit your changes before applying. $(RESET)"; \
-		exit 1; \
-	fi;
-	@if [ "$$(git rev-list --left-only --count HEAD...@'{u}')" != "0" ]; then \
-		echo "$(BOLD)$(RED)✘ERROR: Push your changes to GitHub before applying. $(RESET)"; \
-		exit 1; \
-	fi;
-	@if [ "$$(git rev-list --right-only --count HEAD...@'{u}')" != "0" ]; then \
-		echo "$(BOLD)$(RED)✘ERROR: Pull latest changes from GitHub before applying. $(RESET)"; \
-		exit 1; \
-	fi;
-	@terraform apply

--- a/applications/rogue/main.tf
+++ b/applications/rogue/main.tf
@@ -18,7 +18,7 @@
 #      'd.aed4c-371c-81f5-93d91'), here: <https://papertrailapp.com/groups/4485452>
 #
 # If configuring a production instance:
-#   8. Set 'SLACK_ENDPOINT' & 'SLACK_WEBHOOK_INTEGRATION_URL' for #notify-badass-members integration.
+#   8. Set 'SLACK_WEBHOOK_INTEGRATION_URL' for #notify-badass-members integration.
 #
 # NOTE: We'll move more of these steps into Terraform over time!
 

--- a/applications/rogue/main.tf
+++ b/applications/rogue/main.tf
@@ -59,8 +59,14 @@ variable "with_newrelic" {
   default     = ""
 }
 
+resource "random_id" "etcd_encryption_key" {
+  byte_length = 32
+}
+
 locals {
-  legacy_config_vars = {
+  extra_config_vars = {
+    # TODO: Merge this into the 'heroku_app' module if it works?
+    TEST_APP_KEY = "base64:${random_id.etcd_encryption_key.b64_std}"
   }
 }
 
@@ -83,7 +89,7 @@ module "app" {
     module.queue.config_vars,
     module.iam_user.config_vars,
     module.storage.config_vars,
-    local.legacy_config_vars,
+    local.extra_config_vars,
   )
 
   # We don't run a queue process on development right now. @TODO: Should we?

--- a/applications/rogue/main.tf
+++ b/applications/rogue/main.tf
@@ -60,12 +60,7 @@ variable "with_newrelic" {
 }
 
 locals {
-  # TODO: Remove these once application is updated to use new vars.
   legacy_config_vars = {
-    S3_KEY                = module.iam_user.config_vars["AWS_ACCESS_KEY"]
-    S3_SECRET             = module.iam_user.config_vars["AWS_SECRET_KEY"]
-    SQS_ACCESS_KEY_ID     = module.iam_user.config_vars["AWS_ACCESS_KEY"]
-    SQS_SECRET_ACCESS_KEY = module.iam_user.config_vars["AWS_SECRET_KEY"]
   }
 }
 

--- a/applications/rogue/main.tf
+++ b/applications/rogue/main.tf
@@ -14,9 +14,11 @@
 #      Blink, and set 'DS_ENABLE_BLINK' environment variable to 'true'.
 #   6. Set 'FASTLY_API_TOKEN', 'FASTLY_SERVICE_ID' for the an app-specific Fastly
 #      API Key with the 'global:read' and 'purge_select' permissions.
+#   7. Rename this app's Papertrail system (e.g. 'dosomething-rogue-qa' instead of
+#      'd.aed4c-371c-81f5-93d91'), here: <https://papertrailapp.com/groups/4485452>
 #
 # If configuring a production instance:
-#   7. Set 'SLACK_ENDPOINT' & 'SLACK_WEBHOOK_INTEGRATION_URL' for #notify-badass-members integration.
+#   8. Set 'SLACK_ENDPOINT' & 'SLACK_WEBHOOK_INTEGRATION_URL' for #notify-badass-members integration.
 #
 # NOTE: We'll move more of these steps into Terraform over time!
 

--- a/applications/rogue/main.tf
+++ b/applications/rogue/main.tf
@@ -10,8 +10,8 @@
 #   4. Create app-specific user & machine OAuth clients (via Aurora) and set the
 #      appropriate values for the 'NORTHSTAR_AUTH_ID', 'NORTHSTAR_AUTH_SECRET',
 #      'NORTHSTAR_CLIENT_ID', and 'NORTHSTAR_CLIENT_SECRET' environment vars.
-#   5. Set 'BLINK_URL', 'BLINK_USERNAME', and 'BLINK_PASSWORD' if using
-#      Blink, and set 'DS_ENABLE_BLINK' environment variable to 'true'.
+#   5. If using Blink (for Customer.io), set 'BLINK_USERNAME' and 'BLINK_PASSWORD'
+#      via LastPass & set 'DS_ENABLE_BLINK' environment variable to 'true'.
 #   6. Set 'FASTLY_API_TOKEN', 'FASTLY_SERVICE_ID' for the an app-specific Fastly
 #      API Key with the 'global:read' and 'purge_select' permissions.
 #   7. Rename this app's Papertrail system (e.g. 'dosomething-rogue-qa' instead of
@@ -37,6 +37,14 @@ variable "domain" {
 
 variable "name" {
   description = "The application name."
+}
+
+variable "northstar_url" {
+  description = "The Northstar URL for this environment."
+}
+
+variable "blink_url" {
+  description = "The Blink URL for this environment."
 }
 
 variable "papertrail_destination" {
@@ -66,7 +74,9 @@ resource "random_id" "etcd_encryption_key" {
 locals {
   extra_config_vars = {
     # TODO: Merge this into the 'heroku_app' module if it works?
-    TEST_APP_KEY = "base64:${random_id.etcd_encryption_key.b64_std}"
+    TEST_APP_KEY  = "base64:${random_id.etcd_encryption_key.b64_std}"
+    NORTHSTAR_URL = var.northstar_url
+    BLINK_URL     = var.blink_url
   }
 }
 

--- a/applications/rogue/main.tf
+++ b/applications/rogue/main.tf
@@ -1,17 +1,22 @@
 # This template builds a Rogue application instance.
 #
-# Manual setup steps:
-#   - Set 'APP_KEY' by running 'php artisan generate:key'.
-#   - Set 'ROGUE_API_KEY' to a random string for this instance's v2 API key.
-#   - Create app-specific user & machine OAuth clients (via Aurora) and set the
-#     values for 'NORTHSTAR_URL', 'NORTHSTAR_AUTH_ID', 'NORTHSTAR_AUTH_SECRET',
-#      'NORTHSTAR_CLIENT_ID', and 'NORTHSTAR_CLIENT_SECRET'
-#   - Set 'BLINK_URL', 'BLINK_USERNAME', and 'BLINK_PASSWORD' if using
-#     Blink, and set 'DS_ENABLE_BLINK' environment variable to 'true'.
-#   - Set 'DS_ENABLE_BLINK', 'DS_ENABLE_GLIDE', 'DS_ENABLE_PUSH_TO_QUASAR',
-#     'DS_ENABLE_V3_QUANTITY_SUPPORT', 'FASTLY_API_TOKEN', 'FASTLY_SERVICE_ID',
-#     'FASTLY_URL', 'SLACK_ENDPOINT', and 'SLACK_WEBHOOK_INTEGRATION_URL'.
-#   - Finally, set '/newrelic/api-key' in SSM to the New Relic API Key, if using.
+# To create a new Rogue instance, 
+#   1. Configure this module's variable arguments & apply.
+#   2. The initial apply will fail trying to create 'heroku_formation' resources
+#      because code hasn't been deployed. Deploy this application's `master` branch
+#      via Heroku's web interface & then re-run the apply.
+#   3. Generate an 'APP_KEY' by running 'php artisan generate:key' on a local instance of
+#      this application. Copy-paste that value into `APP_KEY` in Heroku's web interface.
+#   4. Create app-specific user & machine OAuth clients (via Aurora) and set the
+#      appropriate values for the 'NORTHSTAR_AUTH_ID', 'NORTHSTAR_AUTH_SECRET',
+#      'NORTHSTAR_CLIENT_ID', and 'NORTHSTAR_CLIENT_SECRET' environment vars.
+#   5. Set 'BLINK_URL', 'BLINK_USERNAME', and 'BLINK_PASSWORD' if using
+#      Blink, and set 'DS_ENABLE_BLINK' environment variable to 'true'.
+#   6. Set 'FASTLY_API_TOKEN', 'FASTLY_SERVICE_ID' for the an app-specific Fastly
+#      API Key with the 'global:read' and 'purge_select' permissions.
+#
+# If configuring a production instance:
+#   7. Set 'SLACK_ENDPOINT' & 'SLACK_WEBHOOK_INTEGRATION_URL' for #notify-badass-members integration.
 #
 # NOTE: We'll move more of these steps into Terraform over time!
 

--- a/applications/rogue/main.tf
+++ b/applications/rogue/main.tf
@@ -1,10 +1,10 @@
 # This template builds a Rogue application instance.
 #
 # To create a new Rogue instance, 
-#   1. Configure this module's variable arguments & apply.
+#   1. Configure a new 'rogue' module with the required variable arguments & apply.
 #   2. The initial apply will fail trying to create 'heroku_formation' resources
 #      because code hasn't been deployed. Deploy this application's `master` branch
-#      via Heroku's web interface & then re-run the apply.
+#      via Heroku's web interface & then re-run the apply. It should be successful.
 #   3. Generate an 'APP_KEY' by running 'php artisan generate:key' on a local instance of
 #      this application. Copy-paste that value into `APP_KEY` in Heroku's web interface.
 #   4. Create app-specific user & machine OAuth clients (via Aurora) and set the
@@ -12,13 +12,15 @@
 #      'NORTHSTAR_CLIENT_ID', and 'NORTHSTAR_CLIENT_SECRET' environment vars.
 #   5. If using Blink (for Customer.io), set 'BLINK_USERNAME' and 'BLINK_PASSWORD'
 #      via LastPass & set 'DS_ENABLE_BLINK' environment variable to 'true'.
-#   6. Set 'FASTLY_API_TOKEN', 'FASTLY_SERVICE_ID' for the an app-specific Fastly
-#      API Key with the 'global:read' and 'purge_select' permissions.
-#   7. Rename this app's Papertrail system (e.g. 'dosomething-rogue-qa' instead of
+#   6. Set 'FASTLY_SERVICE_ID' to the appropriate Fastly service for this environment.
+#   7. Create an app-specific Fastly API Key with the 'global:read' and 'purge_select'
+#      permissions <https://manage.fastly.com/account/personal/tokens> and set that 
+#      secret in the 'FASTLY_API_TOKEN' environment variable.
+#   8. Rename this app's Papertrail system (e.g. 'dosomething-rogue-qa' instead of
 #      'd.aed4c-371c-81f5-93d91'), here: <https://papertrailapp.com/groups/4485452>
 #
 # If configuring a production instance:
-#   8. Set 'SLACK_WEBHOOK_INTEGRATION_URL' for #notify-badass-members integration.
+#   9. Set 'SLACK_WEBHOOK_INTEGRATION_URL' for #notify-badass-members integration.
 #
 # NOTE: We'll move more of these steps into Terraform over time!
 

--- a/applications/rogue/main.tf
+++ b/applications/rogue/main.tf
@@ -45,6 +45,10 @@ variable "northstar_url" {
   description = "The Northstar URL for this environment."
 }
 
+variable "graphql_url" {
+  description = "The GraphQL gateway URL for this environment."
+}
+
 variable "blink_url" {
   description = "The Blink URL for this environment."
 }
@@ -78,6 +82,7 @@ locals {
     # TODO: Merge this into the 'heroku_app' module if it works?
     TEST_APP_KEY  = "base64:${random_id.etcd_encryption_key.b64_std}"
     NORTHSTAR_URL = var.northstar_url
+    GRAPHQL_URL   = var.graphql_url
     BLINK_URL     = var.blink_url
   }
 }

--- a/dosomething-dev/main.tf
+++ b/dosomething-dev/main.tf
@@ -73,6 +73,8 @@ module "rogue" {
   name                   = "dosomething-rogue-dev"
   domain                 = "activity-dev.dosomething.org"
   pipeline               = var.rogue_pipeline
+  northstar_url          = "https://identity-dev.dosomething.org"
+  blink_url              = "https://blink-staging.dosomething.org/api/"
   papertrail_destination = var.papertrail_destination
 }
 

--- a/dosomething-dev/main.tf
+++ b/dosomething-dev/main.tf
@@ -74,6 +74,7 @@ module "rogue" {
   domain                 = "activity-dev.dosomething.org"
   pipeline               = var.rogue_pipeline
   northstar_url          = "https://identity-dev.dosomething.org"
+  graphql_url            = "https://graphql-dev.dosomething.org/graphql"
   blink_url              = "https://blink-staging.dosomething.org/api/"
   papertrail_destination = var.papertrail_destination
 }

--- a/dosomething-qa/main.tf
+++ b/dosomething-qa/main.tf
@@ -76,6 +76,7 @@ module "rogue" {
   domain                 = "activity-qa.dosomething.org"
   pipeline               = var.rogue_pipeline
   northstar_url          = "https://identity-qa.dosomething.org"
+  graphql_url            = "https://graphql-qa.dosomething.org/graphql"
   blink_url              = "https://blink-staging.dosomething.org/api/"
   papertrail_destination = var.papertrail_destination
 }

--- a/dosomething-qa/main.tf
+++ b/dosomething-qa/main.tf
@@ -75,6 +75,8 @@ module "rogue" {
   name                   = "dosomething-rogue-qa"
   domain                 = "activity-qa.dosomething.org"
   pipeline               = var.rogue_pipeline
+  northstar_url          = "https://identity-qa.dosomething.org"
+  blink_url              = "https://blink-staging.dosomething.org/api/"
   papertrail_destination = var.papertrail_destination
 }
 

--- a/dosomething/main.tf
+++ b/dosomething/main.tf
@@ -117,6 +117,8 @@ module "rogue" {
   name                   = "dosomething-rogue"
   domain                 = "activity.dosomething.org"
   pipeline               = var.rogue_pipeline
+  northstar_url          = "https://identity.dosomething.org"
+  blink_url              = "https://blink.dosomething.org/api/"
   papertrail_destination = var.papertrail_destination
   backup_storage_bucket  = module.rogue_backup.bucket
 }

--- a/dosomething/main.tf
+++ b/dosomething/main.tf
@@ -118,6 +118,7 @@ module "rogue" {
   domain                 = "activity.dosomething.org"
   pipeline               = var.rogue_pipeline
   northstar_url          = "https://identity.dosomething.org"
+  graphql_url            = "https://graphql.dosomething.org/graphql"
   blink_url              = "https://blink.dosomething.org/api/"
   papertrail_destination = var.papertrail_destination
   backup_storage_bucket  = module.rogue_backup.bucket


### PR DESCRIPTION
### What's this PR do?

This pull request updates the "manual setup" steps for Rogue based on [yesterday's fire drill](https://github.com/DoSomething/internal/issues/482).

It removes unnecessary environment variables, like `ROGUE_API_KEY`, `DS_ENABLE_GLIDE`, `DS_ENABLE_PUSH_TO_QUASAR`, `DS_ENABLE_V3_QUANTITY_SUPPORT`, and `FASTLY_URL`. It also adds documentation around the awkward two-step apply & renaming Papertrail sender to be more user-friendly. It also separates out production-only settings, like our Slack integration.

I took a stab at generating `APP_KEY` with Terraform in 622975b (under `TEST_APP_KEY`). It creates 32 random bytes and base-64 encodes them (same as Laravel).

Finally, I removed old `Makefile` tasks that are unused now that we're on Terraform Cloud.

### How should this be reviewed?

Read through the steps. Do they make sense?

### Any background context you want to provide?

📖

### Relevant tickets

References Pivotal [#170775963](https://www.pivotaltracker.com/story/show/170775963), [#170775919](https://www.pivotaltracker.com/story/show/170775919), [#170775797](https://www.pivotaltracker.com/story/show/170775797), and [#170775844](https://www.pivotaltracker.com/story/show/170775844).

### Checklist

- [ ] This PR has been added to the relevant Pivotal card.
