### PR TITLE
Figuring out S3 object path issues...

### DIFF
--- a/components/lambda_function/main.tf
+++ b/components/lambda_function/main.tf
@@ -42,10 +42,7 @@ resource "aws_s3_bucket" "deploy" {
 resource "aws_s3_bucket_object" "release" {
   bucket = aws_s3_bucket.deploy.id
   key    = "release.zip"
-
-  # We hard-code this module's path (from the root) here to avoid an issue
-  # where ${path.module} marks this as "dirty" on different machines.
-  source = "components/lambda_function/default-${var.runtime}.zip"
+  source = "default-${var.runtime}.zip"
 }
 
 # Log group:


### PR DESCRIPTION
### What's this PR do?

This pull request attempts to resolve issues we ran into [when applying](https://app.terraform.io/app/dosomething/workspaces/dosomething-dev/runs/run-2nttM7SpSY4W9WD2) #227:

```
Error: Error opening S3 bucket object source (components/lambda_function/default-nodejs12.x.zip): open components/lambda_function/default-nodejs12.x.zip: no such file or directory

  on ../components/lambda_function/main.tf line 42, in resource "aws_s3_bucket_object" "release":
  42: resource "aws_s3_bucket_object" "release" {
```

We'd originally hard-coded this from the Terraform top-level directory so that we wouldn't get absolute path conflicts between different dev's machines (e.g. `/Users/dfurnes/infrastructure` vs. `/Users/weerd/infrastructure`). But now it doesn't work on Terraform Cloud!

We're hoping that we can either use a relative path, or maybe use `${path.module}` again...

### How should this be reviewed?

Frustratingly, we can't apply this until it's on `master` (and the problem doesn't show up in plans)! If this looks reasonable, we can merge it in and test against `dev`.

### Any background context you want to provide?

(╯°□°)╯︵ ┻━┻ 

### Relevant tickets

References [Pivotal #169276685](https://www.pivotaltracker.com/story/show/169276685).

### Checklist

- [ ] This PR has been added to the relevant Pivotal card.
