### PR TITLE
Retire Longshot application instances.

### DIFF
--- a/applications/longshot/main.tf
+++ b/applications/longshot/main.tf
@@ -62,27 +62,17 @@ locals {
 module "app" {
   source = "../../components/heroku_app"
 
-  framework   = "laravel"
+  framework   = "express"
   name        = var.name
   domain      = var.domain
   pipeline    = var.pipeline
   environment = var.environment
 
-  config_vars = merge(
-    module.database.config_vars,
-    module.queue.config_vars,
-    module.storage.config_vars,
-    module.iam_user.config_vars,
-    local.mail_config_vars,
-  )
-
   web_scale   = 1
-  queue_scale = 1
-
-  with_redis = true
+  queue_scale = 0
 
   papertrail_destination = var.papertrail_destination
-  with_newrelic          = coalesce(var.with_newrelic, var.environment == "production")
+  with_newrelic          = false
 }
 
 module "database" {
@@ -101,12 +91,6 @@ module "database" {
 module "iam_user" {
   source = "../../components/iam_app_user"
   name   = var.name
-}
-
-module "queue" {
-  source = "../../components/sqs_queue"
-  name   = var.name
-  user   = module.iam_user.name
 }
 
 module "storage" {


### PR DESCRIPTION
### What's this PR do?

This pull request updates Longshot application instances to run Express, so we can deploy [this simple application](https://github.com/kenmickles/heroku-redirect) to handle redirects while still using Heroku's ACM for TLS support.

### How should this be reviewed?

👀

### Any background context you want to provide?

This solves a kinda cruddy UX issue (redirects via DNSMadeEasy giving TLS errors if a user had previously visited the HTTPS version hosted by Heroku), and also gets some rather outdated applications off of the internet.

### Relevant tickets

References [Pivotal #168650109](https://www.pivotaltracker.com/story/show/168650109).

### Checklist

- [ ] This PR has been added to the relevant Pivotal card.
