### PR TITLE
Always use 1 queue dyno for Northstar.

### DIFF
--- a/applications/northstar/main.tf
+++ b/applications/northstar/main.tf
@@ -116,12 +116,7 @@ module "app" {
   # We use autoscaling in production, so don't try to manage dynos there.
   ignore_web = var.environment == "production"
 
-  # We don't run a queue process on development right now. @TODO: Should we?
-  queue_scale = {
-    "development" = 0
-    "qa"          = 1
-    "production"  = 3
-  }[var.environment]
+  queue_scale = 1
 
   with_redis = true
   redis_type = var.environment == "production" ? "premium-1" : "hobby-dev"


### PR DESCRIPTION
### What's this PR do?

This pull request updates Northstar to use a single queue dyno across the board – this allows development to delete accounts from all our services (as we do on prod & QA), and reduces costs on production (where we don't need so many queue dynos anymore).

### How should this be reviewed?

👀

### Any background context you want to provide?

We'd originally scaled up Northstar's production queue dynos to deal with a script that produced a lot of queued jobs. Now, we don't need quite so much horsepower. 🏇 

### Relevant tickets

N/A

### Checklist

- [ ] This PR has been added to the relevant Pivotal card.
