### PR TITLE
Grab state and zip code in addition to country code for backend

### DIFF
--- a/dosomething-qa/fastly-backend/main.tf
+++ b/dosomething-qa/fastly-backend/main.tf
@@ -7,6 +7,14 @@ variable "rogue_backend" {}
 variable "papertrail_destination" {}
 variable "papertrail_log_format" {}
 
+locals {
+  headers = {
+    "X-Fastly-Country-Code" = "client.geo.country_code",
+    "X-Fastly-Region-Code"  = "client.geo.region",
+    "X-Fastly-Postal-Code"  = "client.geo.postal_code",
+  }
+}
+
 resource "fastly_service_v1" "backends-qa" {
   name          = "Terraform: Backends (QA)"
   force_destroy = true
@@ -118,20 +126,30 @@ resource "fastly_service_v1" "backends-qa" {
     ]
   }
 
-  header {
-    name        = "Country Code"
-    type        = "request"
-    action      = "set"
-    source      = "geoip.country_code"
-    destination = "http.X-Fastly-Country-Code"
+  # Set headers on incoming HTTP requests, for the backend server.
+  dynamic "header" {
+    for_each = local.headers
+
+    content {
+      name        = "${header.key} (Request)"
+      destination = "http.${header.key}"
+      source      = header.value
+      type        = "request"
+      action      = "set"
+    }
   }
 
-  header {
-    name        = "Country Code (Debug)"
-    type        = "response"
-    action      = "set"
-    source      = "geoip.country_code"
-    destination = "http.X-Fastly-Country-Code"
+  # And set "debug" headers on HTTP responses, for inspection.
+  dynamic "header" {
+    for_each = local.headers
+
+    content {
+      name        = "${header.key} (Response)"
+      destination = "http.${header.key}"
+      source      = header.value
+      type        = "response"
+      action      = "set"
+    }
   }
 
   request_setting {

--- a/dosomething/fastly-backend/main.tf
+++ b/dosomething/fastly-backend/main.tf
@@ -10,6 +10,14 @@ variable "rogue_backend" {}
 variable "papertrail_destination" {}
 variable "papertrail_log_format" {}
 
+locals {
+  headers = {
+    "X-Fastly-Country-Code" = "client.geo.country_code",
+    "X-Fastly-Region-Code"  = "client.geo.region",
+    "X-Fastly-Postal-Code"  = "client.geo.postal_code",
+  }
+}
+
 resource "fastly_service_v1" "backends" {
   name          = "Terraform: Backends"
   force_destroy = true
@@ -152,20 +160,30 @@ resource "fastly_service_v1" "backends" {
     ]
   }
 
-  header {
-    name        = "Country Code"
-    type        = "request"
-    action      = "set"
-    source      = "geoip.country_code"
-    destination = "http.X-Fastly-Country-Code"
+  # Set headers on incoming HTTP requests, for the backend server.
+  dynamic "header" {
+    for_each = local.headers
+
+    content {
+      name        = "${header.key} (Request)"
+      destination = "http.${header.key}"
+      source      = header.value
+      type        = "request"
+      action      = "set"
+    }
   }
 
-  header {
-    name        = "Country Code (Debug)"
-    type        = "response"
-    action      = "set"
-    source      = "geoip.country_code"
-    destination = "http.X-Fastly-Country-Code"
+  # And set "debug" headers on HTTP responses, for inspection.
+  dynamic "header" {
+    for_each = local.headers
+
+    content {
+      name        = "${header.key} (Response)"
+      destination = "http.${header.key}"
+      source      = header.value
+      type        = "response"
+      action      = "set"
+    }
   }
 
   request_setting {


### PR DESCRIPTION
### What's this PR do?

This pull request updates the backend header blocks to dynamically iterate over the locally defined headers we are collecting (same way we already do on the frontend). We also add two headers and now collect zip and state in addition to country.

### How should this be reviewed?

Will we now have access to state and zip from the Northstar registration flow?

### Any background context you want to provide?

All in the card!

### Relevant tickets

References [Pivotal #171522881](https://www.pivotaltracker.com/story/show/171522881).

### Checklist

- [x] This PR has been added to the relevant Pivotal card.
