### PR TITLE
Fix using location with shielding on dev

### DIFF
--- a/dosomething-dev/fastly-backend/main.tf
+++ b/dosomething-dev/fastly-backend/main.tf
@@ -172,6 +172,12 @@ resource "fastly_service_v1" "backends-dev" {
     content = file("${path.module}/app_name.vcl")
   }
 
+  snippet {
+    name    = "Fix Geolocation With Shielding On"
+    type    = "recv"
+    content = file("${path.module}/recv_geolocation.vcl")
+  }
+
   papertrail {
     name    = "backend"
     address = element(split(":", var.papertrail_destination), 0)

--- a/dosomething-dev/fastly-backend/recv_geolocation.vcl
+++ b/dosomething-dev/fastly-backend/recv_geolocation.vcl
@@ -1,0 +1,3 @@
+# Fixes issue where using location variables does not work as expected with shielding
+# https://docs.fastly.com/vcl/geolocation/#using-geographic-variables-with-shielding
+set client.geo.ip_override = req.http.Fastly-Client-IP;


### PR DESCRIPTION
### What's this PR do?

This pull request tries to fix the issues we're seeing where we get location information based on the shielding that's happening rather than the user's actual location.

### How should this be reviewed?

Are we gonna get more accurate locations now?

### Any background context you want to provide?

[Fastly docs](https://docs.fastly.com/vcl/geolocation/#using-geographic-variables-with-shielding)

### Relevant tickets

References [Pivotal #171522881](https://www.pivotaltracker.com/story/show/171522881).

### Checklist

- [ ] This PR has been added to the relevant Pivotal card.
