### PR TITLE
Adding first parts of S3 setup for C.io data pipeline.

### DIFF
--- a/quasar/main.tf
+++ b/quasar/main.tf
@@ -504,7 +504,7 @@ resource "aws_db_instance" "quasar" {
 # Provide S3 Bucket for Customer.io data file exports.
 module "iam_user" {
   source = "../components/iam_app_user"
-  name   = var.name
+  name   = "quasar-cio"
 }
 
 module "storage" {

--- a/quasar/main.tf
+++ b/quasar/main.tf
@@ -499,3 +499,19 @@ resource "aws_db_instance" "quasar" {
   performance_insights_enabled    = true
   enabled_cloudwatch_logs_exports = ["postgresql", "upgrade"]
 }
+
+
+# Provide S3 Bucket for Customer.io data file exports.
+module "iam_user" {
+  source = "../components/iam_app_user"
+  name   = var.name
+}
+
+module "storage" {
+  source = "../components/s3_bucket"
+
+  name       = var.name
+  user       = module.iam_user.name
+  acl        = "private"
+  versioning = true
+}

--- a/quasar/main.tf
+++ b/quasar/main.tf
@@ -502,15 +502,20 @@ resource "aws_db_instance" "quasar" {
 
 
 # Provide S3 Bucket for Customer.io data file exports.
+
+locals {
+  cio_export = "quasar-cio"
+}
+
 module "iam_user" {
   source = "../components/iam_app_user"
-  name   = "quasar-cio"
+  name   = local.cio_export
 }
 
 module "storage" {
   source = "../components/s3_bucket"
 
-  name       = var.name
+  name       = local.cio_export
   user       = module.iam_user.name
   acl        = "private"
   versioning = true


### PR DESCRIPTION
### What's this PR do?

This pull request adds an S3 bucket under the Quasar module to enable using [Customer.io's data export](https://customer.io/docs/data-warehouse-sync) feature. 

### How should this be reviewed?

Will review setup with Furnes, since likely need to add more module code to define specific IAM user for C.io.

### Relevant tickets

References [Pivotal # 172111876](https://www.pivotaltracker.com/story/show/172111876).

### Checklist

- [x] This PR has been added to the relevant Pivotal card.
