### PR TITLE
Updating PostgreSQL to latest patch version and increasing disk space to 6TB.

### DIFF
--- a/quasar/main.tf
+++ b/quasar/main.tf
@@ -482,9 +482,9 @@ resource "aws_db_instance" "quasar-qa" {
 }
 
 resource "aws_db_instance" "quasar" {
-  allocated_storage               = 4000
+  allocated_storage               = 6000
   engine                          = "postgres"
-  engine_version                  = "11.4"
+  engine_version                  = "11.6"
   instance_class                  = "db.m5.4xlarge"
   name                            = "quasar_prod_warehouse"
   username                        = data.aws_ssm_parameter.prod_username.value


### PR DESCRIPTION
### What's this PR do?

This pull request patches PostgreSQL to 1..6, and potentially increases storage to 6TB from 4TB.

### How should this be reviewed?

Terraform Cloud build.

### Any background context you want to provide?

Potential prep PR to increase disk usage on Quasar Prod database as storage needs have gone up.

### Relevant tickets

References [Pivotal #172799812](https://www.pivotaltracker.com/story/show/172799812).

### Checklist

- [ ] This PR has been added to the relevant Pivotal card.
