### PR TITLE
Create applications for Bertly 2.0 in development & QA. 

### DIFF
--- a/applications/bertly/main.tf
+++ b/applications/bertly/main.tf
@@ -1,0 +1,95 @@
+# Experimental: This module builds a serverless GraphQL instance.
+
+# Required variables:
+variable "environment" {
+  description = "The environment for this application: development, qa, or production."
+}
+
+variable "name" {
+  description = "The application name."
+}
+
+variable "northstar_url" {
+  description = "The corresponding Northstar URL."
+}
+
+# Optional variables:
+variable "domain" {
+  description = "The domain this application will be accessible at, e.g. dev.dosome.click"
+  default     = ""
+}
+
+variable "certificate" {
+  description = "The ACM certificate to use for this domain, e.g. *.dosomething.org"
+  default     = ""
+}
+
+variable "logger" {
+  description = "The Lambda function ARN to subscribe to this function's log group."
+  default     = null
+}
+
+data "aws_ssm_parameter" "bertly_api_key" {
+  name = "/${var.name}/api-key"
+}
+
+locals {
+  config_vars = {
+    APP_NAME   = var.name
+    APP_URL    = "https://${var.domain}"
+    APP_SECRET = random_string.app_secret.result
+    NODE_ENV   = "production"
+    LOG_LEVEL  = "info"
+    PORT       = 80
+
+    OPENID_DISCOVERY_URL = var.northstar_url
+    BERTLY_API_KEY_NAME  = "X-BERTLY-API-KEY"
+    BERTLY_API_KEY       = data.aws_ssm_parameter.bertly_api_key.value
+  }
+}
+
+module "app" {
+  source = "../../components/lambda_function"
+
+  name    = var.name
+  handler = "main.handler"
+  runtime = "nodejs12.x"
+  logger  = var.logger
+
+  config_vars = merge(local.config_vars, module.storage.config_vars)
+}
+
+resource "random_string" "app_secret" {
+  length = 32
+}
+
+module "gateway" {
+  source = "../../components/api_gateway_proxy"
+
+  name                = "hello-serverless"
+  function_arn        = "${module.app.arn}"
+  function_invoke_arn = "${module.app.invoke_arn}"
+
+  domain      = var.domain
+  certificate = var.certificate
+}
+
+module "database" {
+  source = "../../components/dynamodb_policy"
+
+  name  = var.name
+  roles = [module.app.lambda_role]
+}
+
+module "storage" {
+  source = "../../components/s3_bucket"
+
+  name = "${var.name}-logs"
+  user = module.app.lambda_role
+  acl  = "private"
+}
+
+output "backend" {
+  value = module.gateway.base_url
+}
+

--- a/components/api_gateway/main.tf
+++ b/components/api_gateway/main.tf
@@ -1,8 +1,3 @@
-locals {
-  # Hack! Check if `var.domain` is a DS.org subdomain. <https://stackoverflow.com/a/47243622/811624>
-  is_dosomething_domain = replace(var.domain, ".dosomething.org", "") != var.domain
-}
-
 resource "aws_api_gateway_rest_api" "gateway" {
   name        = var.name
   description = "Managed with Terraform."
@@ -139,7 +134,7 @@ data "aws_acm_certificate" "certificate" {
 
   # If this is a *.dosomething.org subdomain, use our wildcard ACM certificate.
   # Otherwise, find a certificate for the provided domain (manually provisioned).
-  domain = local.is_dosomething_domain ? "*.dosomething.org" : var.domain
+  domain = var.certificate
 
   statuses = ["ISSUED"]
 }

--- a/components/api_gateway/variables.tf
+++ b/components/api_gateway/variables.tf
@@ -52,3 +52,7 @@ variable "domain" {
   default = ""
 }
 
+variable "certificate" {
+  description = "The ACM certificate to use for this domain, e.g. *.dosomething.org"
+  default     = "*.dosomething.org"
+}

--- a/components/api_gateway_proxy/main.tf
+++ b/components/api_gateway_proxy/main.tf
@@ -1,8 +1,10 @@
 module "api_gateway" {
   source = "../api_gateway"
 
-  name   = var.name
-  domain = var.domain
+  name = var.name
+
+  domain      = var.domain
+  certificate = var.certificate
 
   functions_count = 1
   functions       = [var.function_arn]

--- a/components/api_gateway_proxy/variables.tf
+++ b/components/api_gateway_proxy/variables.tf
@@ -20,3 +20,7 @@ variable "domain" {
   default = ""
 }
 
+variable "certificate" {
+  description = "The ACM certificate to use for this domain, e.g. *.dosomething.org"
+  default     = "*.dosomething.org"
+}

--- a/components/dynamodb_policy/README.md
+++ b/components/dynamodb_policy/README.md
@@ -1,0 +1,18 @@
+# DynamoDB Policy
+
+This module grants an application access to tables in [DynamoDB](https://aws.amazon.com/dynamodb/). An application is allowed to create or update the schema for any tables prefixed by the same `${var.name}-`. For safety, applications cannot delete their tables.
+
+For all options, see the [variables](https://github.com/DoSomething/infrastructure/blob/master/components/dynamodb_policy/variables.tf) this module accepts.
+
+### Usage
+
+This gives a Lambda function the ability to create, read, and write to tables prefixed with `dosomething-bertly-`.
+
+```hcl
+module "database" {
+  source = "../components/dynamodb_policy"
+
+  name  = "dosomething-bertly" 
+  roles = [module.app.lambda_role]
+}
+```

--- a/components/dynamodb_policy/dynamodb-policy.json.tpl
+++ b/components/dynamodb_policy/dynamodb-policy.json.tpl
@@ -1,0 +1,29 @@
+{
+    "Version": "2012-10-17",
+    "Statement": [
+        {
+            "Sid": "SpecificTable",
+            "Resource": "arn:aws:dynamodb:*:*:table/${dynamodb_prefix}-*",
+            "Effect": "Allow",
+            "Action": [
+                "dynamodb:CreateTable",
+                "dynamodb:UpdateTable",
+                "dynamodb:DescribeTable",
+                "dynamodb:DescribeTimeToLive",
+
+
+                "dynamodb:DeleteItem",
+                "dynamodb:GetItem",
+                "dynamodb:BatchGetItem",
+                "dynamodb:PutItem",
+                "dynamodb:UpdateItem",
+                "dynamodb:BatchWriteItem",
+                "dynamodb:TransactGetItems",
+                "dynamodb:TransactWriteItems",
+
+                "dynamodb:Query",
+                "dynamodb:Scan"
+            ]
+        }
+    ]
+}

--- a/components/dynamodb_policy/main.tf
+++ b/components/dynamodb_policy/main.tf
@@ -1,0 +1,12 @@
+resource "aws_iam_policy" "dynamodb_policy" {
+  name = "${var.name}-dynamodb"
+  path = "/"
+
+  policy = templatefile("${path.module}/dynamodb-policy.json.tpl", { dynamodb_prefix = var.name })
+}
+
+resource "aws_iam_role_policy_attachment" "dynamodb_policy" {
+  count      = length(var.roles)
+  role       = var.roles[count.index]
+  policy_arn = aws_iam_policy.dynamodb_policy.arn
+}

--- a/components/dynamodb_policy/variables.tf
+++ b/components/dynamodb_policy/variables.tf
@@ -1,0 +1,9 @@
+# Required variables:
+variable "name" {
+  description = "The application name."
+}
+
+variable "roles" {
+  description = "The IAM roles which should have access to DynamoDB."
+  type        = list(string)
+}

--- a/dosomething-dev/main.tf
+++ b/dosomething-dev/main.tf
@@ -56,6 +56,17 @@ locals {
   papertrail_log_format = "%t '%r' status=%>s app=%%{X-Application-Name}o cache=\"%%{X-Cache}o\" country=%%{X-Fastly-Country-Code}o ip=\"%a\" user-agent=\"%%{User-Agent}i\" service=%%{time.elapsed.msec}Vms"
 }
 
+module "bertly" {
+  source = "../applications/bertly"
+
+  environment   = "development"
+  name          = "dosomething-bertly-dev"
+  domain        = "dev.dosome.click"
+  certificate   = "*.dosome.click"
+  northstar_url = "https://identity-dev.dosomething.org"
+  logger        = module.papertrail
+}
+
 module "fastly-frontend" {
   source = "./fastly-frontend"
 

--- a/dosomething-qa/main.tf
+++ b/dosomething-qa/main.tf
@@ -56,6 +56,17 @@ locals {
   papertrail_log_format = "%t '%r' status=%>s app=%%{X-Application-Name}o cache=\"%%{X-Cache}o\" country=%%{X-Fastly-Country-Code}o ip=\"%a\" user-agent=\"%%{User-Agent}i\" service=%%{time.elapsed.msec}Vms"
 }
 
+module "bertly" {
+  source = "../applications/bertly"
+
+  environment   = "qa"
+  name          = "dosomething-bertly-qa"
+  domain        = "qa.dosome.click"
+  certificate   = "*.dosome.click"
+  northstar_url = "https://identity-qa.dosomething.org"
+  logger        = module.papertrail
+}
+
 module "chompy" {
   source = "../applications/chompy"
 


### PR DESCRIPTION
### What's this PR do?

This pull request configures Bertly's function, gateway, database permissions, and storage bucket. This will allow us to deploy this application & start testing things out in the real world!

### How should this be reviewed?

I've broken this up into individual commits, since there was some pre-work involved:

📝 Adds a `dynamodb_policy` component. This allows us to grant the Lambda function read/write access to any DynamoDB tables prefixed with it's name (e.g. `dosomething-bertly-dev` could use `dosomething-bertly-dev-links`, but not `dosomething-bertly-qa-links`).

This allows the application to manage it's own schema (unlike our `dynamodb_cache` module, where the schema is managed in Terraform). 1044b2e

🎖️ Allows passing a certificate name to API Gateway. Previously, we'd infer this based on the domain (and use `*.dosomething.org` based on some regex magic). Since Bertly uses it's own domain, I think it's easier to just pass this explicitly (defaulting to `*.dosomething.org` if unset). 86f4b11

👋 Creates a `bertly` application module, that creates this application's Lambda function, API gateway (simple proxy), DynamoDB permissions, and private S3 bucket for logs. 1021f30

🍎 Finally, I use that template to create `dosomething-bertly-dev` and `dosomething-bertly-qa`. 
I've held off on creating a production app for now since we're still testing things out. 6554457

### Any background context you want to provide?

![](https://media.giphy.com/media/MtmFbGJ6YsUEg/giphy.gif)

### Relevant tickets

References [Pivotal #172652592](https://www.pivotaltracker.com/story/show/172652592).

### Checklist

- [x] This PR has been added to the relevant Pivotal card.
