### PR TITLE
Update Bertly's handler path.

### DIFF
--- a/applications/bertly/main.tf
+++ b/applications/bertly/main.tf
@@ -52,7 +52,7 @@ module "app" {
   source = "../../components/lambda_function"
 
   name    = var.name
-  handler = "main.handler"
+  handler = "bootstrap/lambda.handler"
   runtime = "nodejs12.x"
   logger  = var.logger
 


### PR DESCRIPTION
### What's this PR do?

This pull request updates Bertly's [handler](https://docs.aws.amazon.com/lambda/latest/dg/nodejs-handler.html) to point to [`bootstrap/lambda.js`'s `handler` export](https://github.com/DoSomething/bertly/blob/master/bootstrap/lambda.js).

### How should this be reviewed?

👀

### Any background context you want to provide?

We've historically defaulted to `main.js`, but I think this is tidier.

### Relevant tickets

References [Pivotal #172652592](https://www.pivotaltracker.com/story/show/172652592).

### Checklist

- [ ] This PR has been added to the relevant Pivotal card.
