### PR TITLE
Deprecate Longshot application resources.

### DIFF
--- a/applications/longshot/main.tf
+++ b/applications/longshot/main.tf
@@ -1,13 +1,6 @@
-# This template builds a Longshot application instance, with
-# database, queue, caching, and storage resources. Be sure to
-# set the application's required SSM parameters before
-# provisioning a new application as well:
-#   - /{name}/rds/username
-#   - /{name}/rds/password
-#   - /mandrill/api-key
-#
-# And required if using New Relic:
-#   - /newrelic/api-key
+# This template manages resources for old Longshot apps,
+# a retired scholarship application run by DSS. We now use
+# Heroku to handle SSL redirects & S3 to keep old storage.
 
 # Required variables:
 variable "environment" {
@@ -26,37 +19,8 @@ variable "domain" {
   description = "The domain this application will be accessible at, e.g. longshot.dosomething.org"
 }
 
-variable "email_name" {
-  description = "The default 'from' name for this application's mail driver."
-}
-
-variable "email_address" {
-  description = "The default email address for this application's mail driver."
-}
-
 variable "papertrail_destination" {
   description = "The Papertrail log destination for this application."
-}
-
-variable "with_newrelic" {
-  # See usage below for default fallback. <https://stackoverflow.com/a/51758050/811624>
-  description = "Should New Relic be enabled for this app? Enabled by default on prod."
-  default     = ""
-}
-
-data "aws_ssm_parameter" "mandrill_api_key" {
-  name = "/mandrill/api-key"
-}
-
-locals {
-  # Environment variables for configuring Mandrill:
-  mail_config_vars = {
-    MAIL_DRIVER     = "mandrill"
-    MAIL_HOST       = "smtp.mandrillapp.com"
-    EMAIL_NAME      = var.email_name
-    EMAIL_ADDRESS   = var.email_address
-    MANDRILL_APIKEY = data.aws_ssm_parameter.mandrill_api_key.value
-  }
 }
 
 module "app" {
@@ -78,6 +42,8 @@ module "app" {
 module "database" {
   source = "../../components/mariadb_instance"
 
+  deprecated = true
+
   name              = var.name
   environment       = var.environment
   database_name     = "longshot"
@@ -88,15 +54,9 @@ module "database" {
   security_groups = ["sg-c9a37db2"]
 }
 
-module "iam_user" {
-  source = "../../components/iam_app_user"
-  name   = var.name
-}
-
 module "storage" {
   source  = "../../components/s3_bucket"
   name    = var.name
-  user    = module.iam_user.name
   private = true
 }
 

--- a/longshot/main.tf
+++ b/longshot/main.tf
@@ -41,20 +41,6 @@ resource "heroku_pipeline" "longshot" {
   name = "longshot"
 }
 
-module "longshot-qa" {
-  source = "../applications/longshot"
-
-  name        = "longshot-qa"
-  domain      = "longshot-qa.dosomething.org"
-  pipeline    = "${heroku_pipeline.longshot.id}"
-  environment = "qa"
-
-  email_name    = "Longshot QA"
-  email_address = "devops@dosomething.org"
-
-  papertrail_destination = "${var.papertrail_qa_destination}"
-}
-
 module "longshot-footlocker" {
   source = "../applications/longshot"
 


### PR DESCRIPTION
### What's this PR do?

This pull request deletes Longshot QA, as it's no longer used (and throwing ACM errors willy nilly).

It also removes Longshot's configuration variables and IAM user, and marks this application's RDS resources for deletion in a follow-up apply (removing "Deletion Protection").

### How should this be reviewed?

👀

### Any background context you want to provide?

🔥

### Relevant tickets

References [Pivotal #169216617](https://www.pivotaltracker.com/story/show/169216617).

### Checklist

- [ ] This PR has been added to the relevant Pivotal card.
