### PR TITLE
Fix an AWS error encountered when applying #253.

### DIFF
--- a/applications/longshot/main.tf
+++ b/applications/longshot/main.tf
@@ -59,6 +59,11 @@ module "database" {
   security_groups = ["sg-c9a37db2"]
 }
 
+module "iam_user" {
+  source = "../../components/iam_app_user"
+  name   = var.name
+}
+
 module "storage" {
   source  = "../../components/s3_bucket"
   name    = var.name

--- a/components/iam_app_user/main.tf
+++ b/components/iam_app_user/main.tf
@@ -4,6 +4,10 @@ variable "name" {
 
 resource "aws_iam_user" "aws_user" {
   name = var.name
+
+  # When destroying this resource, destroy even if it has non-Terraform
+  # managed access keys, policies, etc. See:
+  force_destroy = true
 }
 
 resource "aws_iam_access_key" "aws_key" {

--- a/components/iam_app_user/main.tf
+++ b/components/iam_app_user/main.tf
@@ -6,7 +6,7 @@ resource "aws_iam_user" "aws_user" {
   name = var.name
 
   # When destroying this resource, destroy even if it has non-Terraform
-  # managed access keys, policies, etc. See:
+  # managed access keys, policies, etc. See: https://git.io/JfP7O
   force_destroy = true
 }
 


### PR DESCRIPTION
### What's this PR do?

This pull request (hopefully!) fixes [an issue](https://app.terraform.io/app/dosomething/workspaces/longshot/runs/run-ZcGBsivAvKwyS7Hg) applying #253, where we'd try to delete the IAM user before the attached policies had been deleted. According to [Terraform's documentation](https://www.terraform.io/docs/providers/aws/r/iam_user.html) and [this issue](https://git.io/JfPQF), adding `force_destroy` will let us delete this safely & sidestep this kaboom:

```
Error: Error deleting IAM User longshot-footlocker: DeleteConflict: Cannot delete entity, must delete policies first.
	status code: 409, request id: fc6a7002-5040-44da-a871-514d28a5d077
```

### How should this be reviewed?

Step one is re-adding the IAM user so we can "apply" the `force_destroy` option, step two is trying to delete it again for real. Luckily, we can conditionally apply this per workspace (e.g. Longshot first, dev, QA, and finally prod) so we'll be able to carefully test before it hits the big leagues.

### Any background context you want to provide?

🙃 💥 

### Relevant tickets

References [Pivotal #169216617](https://www.pivotaltracker.com/story/show/169216617).

### Checklist

- [ ] This PR has been added to the relevant Pivotal card.
