### PR TITLE
Add 'fivetran_s3_role' resource & configure for Bertly.

### DIFF
--- a/applications/bertly/main.tf
+++ b/applications/bertly/main.tf
@@ -89,6 +89,14 @@ module "storage" {
   private = true
 }
 
+module "fivetran_role" {
+  source = "../../components/fivetran_s3_role"
+
+  environment = var.environment
+  name        = var.name
+  bucket      = module.storage.bucket
+}
+
 output "backend" {
   value = module.gateway.base_url
 }

--- a/components/fivetran_s3_role/README.md
+++ b/components/fivetran_s3_role/README.md
@@ -1,0 +1,17 @@
+# Fivetran S3 Policy 
+
+This module configures an IAM policy/role to allow [Fivetran](https://fivetran.com) to read the given S3 bucket. We use Fivetran to ingest data into our data warehouse for analysis.
+
+For all options, see the [variables](https://github.com/DoSomething/infrastructure/blob/master/components/fivetran_s3_role/variables.tf) this module accepts & [outputs](https://github.com/DoSomething/infrastructure/blob/master/components/fivetran_s3_role/outputs.tf) it generates.
+
+### Usage
+
+```hcl
+module "fivetran_role" {
+  source = "../components/fivetran_s3_role"
+
+  environment = "qa"
+  name        = "dosomething-example"
+  bucket      = module.storage.bucket
+}
+```

--- a/components/fivetran_s3_role/iam-policy.json.tpl
+++ b/components/fivetran_s3_role/iam-policy.json.tpl
@@ -1,0 +1,21 @@
+{
+  "Version": "2012-10-17",
+  "Statement": [
+    {
+      "Effect": "Allow",
+      "Action": [
+        "s3:Get*",
+        "s3:List*"
+      ],
+      "Resource": "${bucket_arn}/*"
+    },
+    {
+      "Effect": "Allow",
+      "Action": [
+        "s3:Get*",
+        "s3:List*"
+      ],
+      "Resource": "${bucket_arn}"
+    }
+  ]
+}

--- a/components/fivetran_s3_role/iam-role.json.tpl
+++ b/components/fivetran_s3_role/iam-role.json.tpl
@@ -1,0 +1,11 @@
+{
+    "Version": "2012-10-17",
+    "Principal": {
+        "AWS": "${fivetran_account_id}"
+    },
+    "Condition" : {
+        "StringEquals": {
+            "sts:ExternalId": "${external_id}" 
+        }
+    }
+  }

--- a/components/fivetran_s3_role/main.tf
+++ b/components/fivetran_s3_role/main.tf
@@ -1,0 +1,19 @@
+data "aws_ssm_parameter" "external_id" {
+  name = "/fivetran/${var.environment}/external-id"
+}
+
+resource "aws_iam_policy" "fivetran_policy" {
+  name = "${var.name}-s3-fivetran"
+  policy = templatefile("${path.module}/iam-policy.json.tpl", {
+    bucket_arn = var.bucket.arn
+  })
+}
+
+resource "aws_iam_role" "fivetran_role" {
+  name = "${var.name}-s3-fivetran"
+
+  assume_role_policy = templatefile("${path.module}/iam-role.json.tpl", {
+    fivetran_account_id = 834469178297
+    external_id         = data.aws_ssm_parameter.external_id.value
+  })
+}

--- a/components/fivetran_s3_role/outputs.tf
+++ b/components/fivetran_s3_role/outputs.tf
@@ -1,0 +1,4 @@
+output "role_arn" {
+  description = "The Fivetran Role ARN. This is provided in the connector setup form."
+  value       = aws_iam_role.fivetran_role.arn
+}

--- a/components/fivetran_s3_role/variables.tf
+++ b/components/fivetran_s3_role/variables.tf
@@ -1,0 +1,11 @@
+variable "environment" {
+  description = "The environment we're using: development, qa, or production."
+}
+
+variable "name" {
+  description = "The application name, e.g. 'dosomething-bertly'."
+}
+
+variable "bucket" {
+  description = "The s3_bucket resource to configure a Fivetran connector for."
+}


### PR DESCRIPTION
### What's this PR do?

This pull request adds a [`fivetran_s3_role`](https://github.com/DoSomething/infrastructure/tree/fivetran-s3-role/components/fivetran_s3_role) module, which allows Fivetran to access buckets on our account.

### How should this be reviewed?

This is based on the [Fivetran S3 Setup Guide](https://fivetran.com/docs/files/aws-s3/setup-guide) here, and follows the example set by @blisteringherb's work in #250 (to add a similar connection for CloudWatch logs). Since we want to give Fivetran access to only a few specific buckets, I've opted to add this as a resource that we attach to any buckets that need it (rather than a standalone "global" role).

I'll try creating a connector on development & QA (which have relatively few clicks) before doing so on production.

### Any background context you want to provide?

This will allow us to replicate this private S3 bucket (where Bertly 2.0 stores click information) into our data warehouse with Fivetran. We're storing clicks here, instead of PostgreSQL, to save money & hopefully reduce complexity.

### Relevant tickets

References [Pivotal #172652716](https://www.pivotaltracker.com/story/show/172652716).

### Checklist

- [ ] This PR has been added to the relevant Pivotal card.
