### PR TITLE
Add additional tags to AWS resources.

### DIFF
--- a/applications/bertly/main.tf
+++ b/applications/bertly/main.tf
@@ -34,6 +34,9 @@ data "aws_ssm_parameter" "bertly_api_key" {
 }
 
 locals {
+  # This application is part of our backend stack.
+  stack = "backend"
+
   config_vars = {
     APP_NAME   = var.name
     APP_URL    = "https://${var.domain}"
@@ -51,7 +54,10 @@ locals {
 module "app" {
   source = "../../components/lambda_function"
 
-  name    = var.name
+  name        = var.name
+  environment = var.environment
+  stack       = local.stack
+
   handler = "bootstrap/lambda.handler"
   runtime = "nodejs12.x"
   logger  = var.logger
@@ -66,7 +72,10 @@ resource "random_string" "app_secret" {
 module "gateway" {
   source = "../../components/api_gateway_proxy"
 
-  name                = var.name
+  name        = var.name
+  environment = var.environment
+  stack       = local.stack
+
   function_arn        = module.app.arn
   function_invoke_arn = module.app.invoke_arn
 
@@ -84,7 +93,10 @@ module "database" {
 module "storage" {
   source = "../../components/s3_bucket"
 
-  name    = "${var.name}-logs"
+  name        = "${var.name}-logs"
+  environment = var.environment
+  stack       = local.stack
+
   roles   = [module.app.lambda_role]
   private = true
 }

--- a/applications/graphql/main.tf
+++ b/applications/graphql/main.tf
@@ -65,12 +65,18 @@ locals {
 
   # Gambit only has a production & QA environment:
   gambit_env = local.env == "dev" ? "qa" : local.env
+
+  # This application is part of our backend stack.
+  stack = "backend"
 }
 
 module "app" {
   source = "../../components/lambda_function"
 
-  name    = var.name
+  name        = var.name
+  environment = var.environment
+  stack       = local.stack
+
   handler = "main.handler"
   runtime = "nodejs12.x"
   logger  = var.logger
@@ -109,7 +115,10 @@ resource "random_string" "webhook_secret" {
 module "contentful_webhook" {
   source = "../../components/lambda_function"
 
-  name    = "${var.name}-webhook"
+  name        = "${var.name}-webhook"
+  environment = var.environment
+  stack       = local.stack
+
   handler = "webhook.handler"
   runtime = "nodejs12.x"
   logger  = var.logger
@@ -126,7 +135,10 @@ module "contentful_webhook" {
 module "gateway" {
   source = "../../components/api_gateway"
 
-  name   = var.name
+  name        = var.name
+  environment = var.environment
+  stack       = local.stack
+
   domain = var.domain
 
   functions_count = 2
@@ -151,7 +163,10 @@ module "gateway" {
 module "cache" {
   source = "../../components/dynamodb_cache"
 
-  name  = "${var.name}-cache"
+  name        = "${var.name}-cache"
+  environment = var.environment
+  stack       = local.stack
+
   roles = [module.app.lambda_role, module.contentful_webhook.lambda_role]
 }
 

--- a/applications/hello-serverless/main.tf
+++ b/applications/hello-serverless/main.tf
@@ -5,7 +5,10 @@ variable "logger" {
 module "app" {
   source = "../../components/lambda_function"
 
-  name    = "hello-serverless"
+  name        = "hello-serverless"
+  environment = "development"
+  stack       = "web"
+
   runtime = "nodejs12.x"
   logger  = var.logger
 }
@@ -13,7 +16,10 @@ module "app" {
 module "gateway" {
   source = "../../components/api_gateway_proxy"
 
-  name                = "hello-serverless"
+  name        = "hello-serverless"
+  environment = "development"
+  stack       = "web"
+
   function_arn        = module.app.arn
   function_invoke_arn = module.app.invoke_arn
   domain              = "hello-serverless.dosomething.org"

--- a/applications/longshot/main.tf
+++ b/applications/longshot/main.tf
@@ -45,8 +45,12 @@ module "app" {
 }
 
 module "storage" {
-  source   = "../../components/s3_bucket"
-  name     = var.name
+  source = "../../components/s3_bucket"
+
+  name        = var.name
+  environment = var.environment
+  stack       = "web"
+
   private  = true
   archived = true
 }

--- a/applications/lookerbot/main.tf
+++ b/applications/lookerbot/main.tf
@@ -27,7 +27,10 @@ module "iam_user" {
 module "storage" {
   source = "../../components/s3_bucket"
 
-  name    = var.name
+  name        = var.name
+  environment = "production"
+  stack       = "data"
+
   user    = module.iam_user.name
   private = false
 }

--- a/applications/northstar/main.tf
+++ b/applications/northstar/main.tf
@@ -92,6 +92,9 @@ locals {
     DS_ENABLE_PASSWORD_GRANT = false
     DS_ENABLE_RATE_LIMITING  = true
   }
+
+  # This application is part of our backend stack.
+  stack = "backend"
 }
 
 module "app" {
@@ -133,21 +136,30 @@ module "iam_user" {
 module "queue_high" {
   source = "../../components/sqs_queue"
 
-  name = "${var.name}-high"
+  name        = "${var.name}-high"
+  environment = var.environment
+  stack       = local.stack
+
   user = module.iam_user.name
 }
 
 module "queue_low" {
   source = "../../components/sqs_queue"
 
-  name = "${var.name}-low"
+  name        = "${var.name}-low"
+  environment = var.environment
+  stack       = local.stack
+
   user = module.iam_user.name
 }
 
 module "storage" {
   source = "../../components/s3_bucket"
 
-  name       = var.name
+  name        = var.name
+  environment = var.environment
+  stack       = local.stack
+
   user       = module.iam_user.name
   private    = true
   versioning = true

--- a/applications/papertrail/main.tf
+++ b/applications/papertrail/main.tf
@@ -13,7 +13,10 @@ variable "papertrail_destination" {
 module "forwarder" {
   source = "../../components/lambda_function"
 
-  name    = var.name
+  name        = var.name
+  environment = var.environment
+  stack       = "backend"
+
   runtime = "nodejs12.x"
   handler = "handler.log"
 

--- a/applications/phoenix/main.tf
+++ b/applications/phoenix/main.tf
@@ -79,6 +79,9 @@ locals {
     CONTENTFUL_USE_PREVIEW_API = var.use_contentful_preview_api
     CONTENTFUL_CACHE           = false == var.use_contentful_preview_api
   }
+
+  # This application is part of our frontend stack.
+  stack = "web"
 }
 
 module "app" {
@@ -109,8 +112,10 @@ module "app" {
 module "database" {
   source = "../../components/mariadb_instance"
 
-  name           = var.name
-  environment    = var.environment
+  name        = var.name
+  environment = var.environment
+  stack       = local.stack
+
   instance_class = var.environment == "production" ? "db.t2.medium" : "db.t2.micro"
 }
 

--- a/applications/rogue/main.tf
+++ b/applications/rogue/main.tf
@@ -90,6 +90,9 @@ locals {
     GRAPHQL_URL   = var.graphql_url
     BLINK_URL     = var.blink_url
   }
+
+  # This application is part of our backend stack.
+  stack = "backend"
 }
 
 module "app" {
@@ -126,8 +129,10 @@ module "app" {
 module "database" {
   source = "../../components/mariadb_instance"
 
-  name           = var.name
-  environment    = var.environment
+  name        = var.name
+  environment = var.environment
+  stack       = local.stack
+
   instance_class = var.environment == "production" ? "db.m4.large" : "db.t2.medium"
   multi_az       = var.environment == "production"
   is_dms_source  = true
@@ -141,14 +146,22 @@ module "iam_user" {
 
 module "queue" {
   source = "../../components/sqs_queue"
-  name   = var.name
-  user   = module.iam_user.name
+
+  name        = var.name
+  environment = var.environment
+  stack       = local.stack
+
+  user = module.iam_user.name
 }
 
 module "storage" {
   source = "../../components/s3_bucket"
-  name   = var.name
-  user   = module.iam_user.name
+
+  name        = var.name
+  environment = var.environment
+  stack       = local.stack
+
+  user = module.iam_user.name
 
   replication_target = var.backup_storage_bucket
 }

--- a/applications/static/main.tf
+++ b/applications/static/main.tf
@@ -2,6 +2,14 @@ variable "domain" {
   description = "The domain this bucket will be accessible at, e.g. assets.dosomething.org"
 }
 
+variable "environment" {
+  description = "The environment for this bucket: development, qa, or production."
+}
+
+variable "stack" {
+  description = "The 'stack' for this bucket: web, sms, backend, data."
+}
+
 resource "aws_s3_bucket" "bucket" {
   bucket = var.domain
   acl    = "public-read"
@@ -16,6 +24,12 @@ resource "aws_s3_bucket" "bucket" {
 
     # Allow CORS requests from DS.org properties & local development apps.
     allowed_origins = ["https://*.dosomething.org", "http://*.test"]
+  }
+
+  tags = {
+    Application = var.domain
+    Environment = var.environment
+    Stack       = var.stack
   }
 }
 

--- a/components/api_gateway/main.tf
+++ b/components/api_gateway/main.tf
@@ -1,6 +1,12 @@
 resource "aws_api_gateway_rest_api" "gateway" {
   name        = var.name
   description = "Managed with Terraform."
+
+  tags = {
+    Application = var.name
+    Environment = var.environment
+    Stack       = var.stack
+  }
 }
 
 # Configure the root resource method & integration:

--- a/components/api_gateway/variables.tf
+++ b/components/api_gateway/variables.tf
@@ -3,6 +3,14 @@ variable "name" {
   description = "The application name."
 }
 
+variable "environment" {
+  description = "The environment for this gateway: development, qa, or production."
+}
+
+variable "stack" {
+  description = "The 'stack' for this gateway: web, sms, backend, data."
+}
+
 variable "functions_count" {
   # Temporary hack to work around Terraform 0.11 limitation. <https://git.io/fjLYC>
 }

--- a/components/api_gateway_proxy/main.tf
+++ b/components/api_gateway_proxy/main.tf
@@ -1,7 +1,9 @@
 module "api_gateway" {
   source = "../api_gateway"
 
-  name = var.name
+  name        = var.name
+  environment = var.environment
+  stack       = var.stack
 
   domain      = var.domain
   certificate = var.certificate

--- a/components/api_gateway_proxy/variables.tf
+++ b/components/api_gateway_proxy/variables.tf
@@ -3,6 +3,14 @@ variable "name" {
   description = "The application name."
 }
 
+variable "environment" {
+  description = "The environment for this gateway: development, qa, or production."
+}
+
+variable "stack" {
+  description = "The 'stack' for this gateway: web, sms, backend, data."
+}
+
 variable "function_arn" {
   description = "The Lambda function's ARN."
 }

--- a/components/dynamodb_cache/main.tf
+++ b/components/dynamodb_cache/main.tf
@@ -3,6 +3,14 @@ variable "name" {
   description = "The application name."
 }
 
+variable "environment" {
+  description = "The environment for this database: development, qa, or production."
+}
+
+variable "stack" {
+  description = "The 'stack' for this database: web, sms, backend, data."
+}
+
 variable "roles" {
   description = "The IAM roles which should have access to this resource."
   type        = list(string)
@@ -23,6 +31,12 @@ resource "aws_dynamodb_table" "table" {
   attribute {
     name = "id"
     type = "S"
+  }
+
+  tags = {
+    Application = var.name
+    Environment = var.environment
+    Stack       = var.stack
   }
 }
 

--- a/components/lambda_function/main.tf
+++ b/components/lambda_function/main.tf
@@ -27,6 +27,12 @@ resource "aws_lambda_function" "function" {
   }
 
   role = aws_iam_role.lambda_exec.arn
+
+  tags = {
+    Application = var.name
+    Environment = var.environment
+    Stack       = var.stack
+  }
 }
 
 # Deploy artifacts:

--- a/components/lambda_function/variables.tf
+++ b/components/lambda_function/variables.tf
@@ -3,6 +3,14 @@ variable "name" {
   description = "The application name."
 }
 
+variable "environment" {
+  description = "The environment for this Lambda: development, qa, or production."
+}
+
+variable "stack" {
+  description = "The 'stack' for this Lambda: web, sms, backend, data."
+}
+
 variable "runtime" {
   description = "The Lambda runtime to use. We support nodejs12.x, python2.7, and python3.7"
 }

--- a/components/mariadb_instance/main.tf
+++ b/components/mariadb_instance/main.tf
@@ -7,6 +7,10 @@ variable "environment" {
   description = "The environment for this database: development, qa, or production."
 }
 
+variable "stack" {
+  description = "The 'stack' for this database: web, sms, backend, data."
+}
+
 variable "instance_class" {
   description = "The RDS instance class. See: https://goo.gl/vTMqx9"
 }
@@ -90,6 +94,12 @@ resource "aws_db_parameter_group" "replication_settings" {
     name  = "binlog_checksum"
     value = "NONE"
   }
+
+  tags = {
+    Application = var.name
+    Environment = var.environment
+    Stack       = var.stack
+  }
 }
 
 resource "random_string" "master_password" {
@@ -137,6 +147,8 @@ resource "aws_db_instance" "database" {
 
   tags = {
     Application = var.name
+    Environment = var.environment
+    Stack       = var.stack
   }
 }
 

--- a/components/postgresql_warehouse/main.tf
+++ b/components/postgresql_warehouse/main.tf
@@ -1,5 +1,13 @@
+variable "name" {
+  description = "The name for this warehouse."
+}
+
+variable "environment" {
+  description = "The environment for this database: development, qa, or production."
+}
+
 variable "database_name" {
-  description = "The name used for this database."
+  description = "The name used for the default database."
 }
 
 variable "engine_version" {
@@ -40,6 +48,10 @@ variable "work_mem" {
 
 variable "vpc_security_group_ids" {
   description = "The VPC security group IDs to grant access to this database."
+}
+
+locals {
+  stack = "data"
 }
 
 resource "aws_db_parameter_group" "pg11" {
@@ -148,6 +160,12 @@ resource "aws_db_parameter_group" "pg11" {
     name  = "log_autovacuum_min_duration"
     value = "0"
   }
+
+  tags = {
+    Application = var.name
+    Environment = var.environment
+    Stack       = local.stack
+  }
 }
 
 resource "aws_db_instance" "quasar" {
@@ -168,4 +186,10 @@ resource "aws_db_instance" "quasar" {
   publicly_accessible             = true
   performance_insights_enabled    = true
   enabled_cloudwatch_logs_exports = ["postgresql", "upgrade"]
+
+  tags = {
+    Application = var.name
+    Environment = var.environment
+    Stack       = local.stack
+  }
 }

--- a/components/quasar_vpc/main.tf
+++ b/components/quasar_vpc/main.tf
@@ -1,11 +1,24 @@
 # This is the Quasar VPC layout.
 
+locals {
+  name = "dosomething-quasar"
+
+  # NOTE: We share these resources between all environments.
+  environment = "production"
+
+  # These are all for our data stack.
+  stack = "data"
+}
+
 # Quasar VPC IP Range:
 resource "aws_vpc" "quasar_vpc" {
   cidr_block = "10.255.0.0/16"
 
   tags = {
-    Name = "Quasar"
+    Name        = "Quasar"
+    Application = local.name
+    Environment = local.environment
+    Stack       = local.stack
   }
 }
 
@@ -15,7 +28,10 @@ resource "aws_subnet" "subnet-a" {
   cidr_block = "10.255.100.0/24"
 
   tags = {
-    Name = "Quasar RDS - 1A"
+    Name        = "Quasar RDS - 1A"
+    Application = local.name
+    Environment = local.environment
+    Stack       = local.stack
   }
 }
 
@@ -25,7 +41,10 @@ resource "aws_subnet" "subnet-b" {
   cidr_block = "10.255.101.0/24"
 
   tags = {
-    Name = "Quasar RDS - 1E"
+    Name        = "Quasar RDS - 1E"
+    Application = local.name
+    Environment = local.environment
+    Stack       = local.stack
   }
 }
 
@@ -38,7 +57,10 @@ resource "aws_security_group" "bastion" {
   vpc_id      = aws_vpc.quasar_vpc.id
 
   tags = {
-    Name = "Quasar-Bastion"
+    Name        = "Quasar-Bastion"
+    Application = local.name
+    Environment = local.environment
+    Stack       = local.stack
   }
 }
 
@@ -71,7 +93,10 @@ resource "aws_security_group" "jenkins" {
   vpc_id      = aws_vpc.quasar_vpc.id
 
   tags = {
-    Name = "Quasar-Jenkins"
+    Name        = "Quasar-Jenkins"
+    Application = local.name
+    Environment = local.environment
+    Stack       = local.stack
   }
 }
 
@@ -108,7 +133,10 @@ resource "aws_security_group" "haproxy" {
   vpc_id      = aws_vpc.quasar_vpc.id
 
   tags = {
-    Name = "Quasar-HA-Proxy"
+    Name        = "Quasar-HA-Proxy"
+    Application = local.name
+    Environment = local.environment
+    Stack       = local.stack
   }
 }
 
@@ -161,7 +189,10 @@ resource "aws_security_group" "etl" {
   vpc_id      = aws_vpc.quasar_vpc.id
 
   tags = {
-    Name = "Quasar-ETL"
+    Name        = "Quasar-ETL"
+    Application = local.name
+    Environment = local.environment
+    Stack       = local.stack
   }
 }
 
@@ -200,7 +231,10 @@ resource "aws_security_group" "rds" {
   vpc_id      = aws_vpc.quasar_vpc.id
 
   tags = {
-    Name = "Quasar-RDS"
+    Name        = "Quasar-RDS"
+    Application = local.name
+    Environment = local.environment
+    Stack       = local.stack
   }
 }
 

--- a/components/s3_bucket/main.tf
+++ b/components/s3_bucket/main.tf
@@ -3,6 +3,14 @@ variable "name" {
   description = "The name for this bucket (usually the application name)."
 }
 
+variable "environment" {
+  description = "The environment for this bucket: development, qa, or production."
+}
+
+variable "stack" {
+  description = "The 'stack' for this bucket: web, sms, backend, data."
+}
+
 # Optional variables:
 variable "user" {
   description = "The IAM user to grant permissions to read/write to this bucket."
@@ -91,6 +99,8 @@ resource "aws_s3_bucket" "bucket" {
 
   tags = {
     Application = var.name
+    Environment = var.environment
+    Stack       = var.stack
   }
 }
 

--- a/components/sqs_queue/main.tf
+++ b/components/sqs_queue/main.tf
@@ -3,6 +3,14 @@ variable "name" {
   description = "The name for this queue (usually the application name)."
 }
 
+variable "environment" {
+  description = "The environment for this queue: development, qa, or production."
+}
+
+variable "stack" {
+  description = "The 'stack' for this queue: web, sms, backend, data."
+}
+
 variable "user" {
   description = "The IAM user to grant permissions to read/write to this queue."
 }
@@ -10,6 +18,12 @@ variable "user" {
 resource "aws_sqs_queue" "queue" {
   name                      = var.name
   message_retention_seconds = 60 * 60 * 24 * 14 # 14 days (maximum).
+
+  tags = {
+    Application = var.name
+    Environment = var.environment
+    Stack       = var.stack
+  }
 }
 
 data "template_file" "sqs_policy" {

--- a/dosomething/main.tf
+++ b/dosomething/main.tf
@@ -59,7 +59,9 @@ locals {
 module "assets" {
   source = "../applications/static"
 
-  domain = "assets.dosomething.org"
+  domain      = "assets.dosomething.org"
+  environment = "production"
+  stack       = "web"
 }
 
 module "bertly" {
@@ -159,7 +161,10 @@ module "rogue_backup" {
     aws = aws.west
   }
 
-  name       = "dosomething-rogue-backup"
+  name        = "dosomething-rogue-backup"
+  environment = "production"
+  stack       = "web"
+
   versioning = true
   archived   = true
   private    = true

--- a/quasar/main.tf
+++ b/quasar/main.tf
@@ -57,6 +57,9 @@ module "vpc" {
 module "warehouse" {
   source = "../components/postgresql_warehouse"
 
+  name        = "dosomething-quasar"
+  environment = "production"
+
   database_name        = "quasar_prod_warehouse"
   parameter_group_name = "quasar-prod-pg11"
   instance_class       = "db.m5.4xlarge"
@@ -74,6 +77,9 @@ module "warehouse" {
 
 module "warehouse-qa" {
   source = "../components/postgresql_warehouse"
+
+  name        = "dosomething-quasar-qa"
+  environment = "qa"
 
   database_name        = "quasar" # TODO: This is misleading!
   parameter_group_name = "quasar-qa-pg11"
@@ -103,7 +109,10 @@ module "iam_user" {
 module "storage" {
   source = "../components/s3_bucket"
 
-  name       = local.cio_export
+  name        = local.cio_export
+  environment = "production"
+  stack       = "data"
+
   user       = module.iam_user.name
   versioning = true
   private    = true

--- a/vote-instapage/main.tf
+++ b/vote-instapage/main.tf
@@ -147,5 +147,11 @@ resource "aws_s3_bucket" "vote" {
     index_document = "index.html"
     error_document = "error.html"
   }
+
+  tags = {
+    Application = "vote.dosomething.org"
+    Environment = "production"
+    Stack       = "web"
+  }
 }
 

--- a/voting-app/main.tf
+++ b/voting-app/main.tf
@@ -65,6 +65,9 @@ resource "fastly_service_v1" "voting-app" {
 
 module "agg" {
   source = "../applications/static"
-  domain = "www.athletesgonegood.com"
+
+  domain      = "www.athletesgonegood.com"
+  environment = "production"
+  stack       = "web"
 }
 


### PR DESCRIPTION
### What's this PR do?

This pull request adds additional "tags" to AWS resources. These can be used to filter items in the web console (e.g. "show me all production databases") or CLI, or for analyzing our bill to see breakdown & trends by app.

I decided to start by categorizing our resources by:
- `Application` (e.g. `dosomething-northstar`)
- `Environment` (e.g. `development` or `production`)
- `Stack` (e.g. `web`, `backend`, or `data`).

I'm open to better naming for that last one – the idea is to have a way to group different "domain contexts" so we can group different parts of our stack. I considered `Context` but it seemed nebulous, and [`Domain`](https://en.wikipedia.org/wiki/Domain-driven_design) but figured it could be confused with a web domain.

And we can always adjust or add more tags in the future!

### How should this be reviewed?

👀

### Any background context you want to provide?

I know the diff looks scary, but it's all very straightforward changes!

### Relevant tickets

References [Pivotal #173665994](https://www.pivotaltracker.com/story/show/173665994).

### Checklist

- [ ] This PR has been added to the relevant Pivotal card.
