### PR TITLE
Fix some issues with new AWS tags.

### DIFF
--- a/applications/bertly/main.tf
+++ b/applications/bertly/main.tf
@@ -54,6 +54,7 @@ locals {
 module "app" {
   source = "../../components/lambda_function"
 
+  application = var.name
   name        = var.name
   environment = var.environment
   stack       = local.stack
@@ -93,6 +94,7 @@ module "database" {
 module "storage" {
   source = "../../components/s3_bucket"
 
+  application = var.name
   name        = "${var.name}-logs"
   environment = var.environment
   stack       = local.stack

--- a/applications/graphql/main.tf
+++ b/applications/graphql/main.tf
@@ -73,6 +73,7 @@ locals {
 module "app" {
   source = "../../components/lambda_function"
 
+  application = var.name
   name        = var.name
   environment = var.environment
   stack       = local.stack
@@ -115,6 +116,7 @@ resource "random_string" "webhook_secret" {
 module "contentful_webhook" {
   source = "../../components/lambda_function"
 
+  application = var.name
   name        = "${var.name}-webhook"
   environment = var.environment
   stack       = local.stack
@@ -163,6 +165,7 @@ module "gateway" {
 module "cache" {
   source = "../../components/dynamodb_cache"
 
+  application = var.name
   name        = "${var.name}-cache"
   environment = var.environment
   stack       = local.stack

--- a/applications/hello-serverless/main.tf
+++ b/applications/hello-serverless/main.tf
@@ -5,6 +5,7 @@ variable "logger" {
 module "app" {
   source = "../../components/lambda_function"
 
+  application = "hello-serverless"
   name        = "hello-serverless"
   environment = "development"
   stack       = "web"

--- a/applications/longshot/main.tf
+++ b/applications/longshot/main.tf
@@ -47,6 +47,7 @@ module "app" {
 module "storage" {
   source = "../../components/s3_bucket"
 
+  application = "dosomething-longshot"
   name        = var.name
   environment = var.environment
   stack       = "web"

--- a/applications/lookerbot/main.tf
+++ b/applications/lookerbot/main.tf
@@ -27,6 +27,7 @@ module "iam_user" {
 module "storage" {
   source = "../../components/s3_bucket"
 
+  application = var.name
   name        = var.name
   environment = "production"
   stack       = "data"

--- a/applications/northstar/main.tf
+++ b/applications/northstar/main.tf
@@ -136,6 +136,7 @@ module "iam_user" {
 module "queue_high" {
   source = "../../components/sqs_queue"
 
+  application = var.name
   name        = "${var.name}-high"
   environment = var.environment
   stack       = local.stack
@@ -146,6 +147,7 @@ module "queue_high" {
 module "queue_low" {
   source = "../../components/sqs_queue"
 
+  application = var.name
   name        = "${var.name}-low"
   environment = var.environment
   stack       = local.stack
@@ -156,6 +158,7 @@ module "queue_low" {
 module "storage" {
   source = "../../components/s3_bucket"
 
+  application = var.name
   name        = var.name
   environment = var.environment
   stack       = local.stack

--- a/applications/papertrail/main.tf
+++ b/applications/papertrail/main.tf
@@ -14,6 +14,7 @@ module "forwarder" {
   source = "../../components/lambda_function"
 
   name        = var.name
+  application = var.name
   environment = var.environment
   stack       = "backend"
 

--- a/applications/rogue/main.tf
+++ b/applications/rogue/main.tf
@@ -147,6 +147,7 @@ module "iam_user" {
 module "queue" {
   source = "../../components/sqs_queue"
 
+  application = var.name
   name        = var.name
   environment = var.environment
   stack       = local.stack
@@ -157,6 +158,7 @@ module "queue" {
 module "storage" {
   source = "../../components/s3_bucket"
 
+  application = var.name
   name        = var.name
   environment = var.environment
   stack       = local.stack

--- a/components/dynamodb_cache/main.tf
+++ b/components/dynamodb_cache/main.tf
@@ -1,6 +1,6 @@
 # Required variables:
 variable "name" {
-  description = "The application name."
+  description = "The DynamoDB table name."
 }
 
 variable "environment" {

--- a/components/dynamodb_cache/main.tf
+++ b/components/dynamodb_cache/main.tf
@@ -3,6 +3,10 @@ variable "name" {
   description = "The DynamoDB table name."
 }
 
+variable "application" {
+  description = "The application this cache is provisioned for (e.g. 'dosomething-graphql')."
+}
+
 variable "environment" {
   description = "The environment for this database: development, qa, or production."
 }
@@ -34,7 +38,7 @@ resource "aws_dynamodb_table" "table" {
   }
 
   tags = {
-    Application = var.name
+    Application = var.application
     Environment = var.environment
     Stack       = var.stack
   }

--- a/components/lambda_function/main.tf
+++ b/components/lambda_function/main.tf
@@ -43,6 +43,12 @@ resource "aws_s3_bucket" "deploy" {
   versioning {
     enabled = true
   }
+
+  tags = {
+    Application = var.application
+    Environment = var.environment
+    Stack       = var.stack
+  }
 }
 
 resource "aws_s3_bucket_public_access_block" "private_policy" {

--- a/components/lambda_function/main.tf
+++ b/components/lambda_function/main.tf
@@ -29,7 +29,7 @@ resource "aws_lambda_function" "function" {
   role = aws_iam_role.lambda_exec.arn
 
   tags = {
-    Application = var.name
+    Application = var.application
     Environment = var.environment
     Stack       = var.stack
   }

--- a/components/lambda_function/variables.tf
+++ b/components/lambda_function/variables.tf
@@ -3,6 +3,10 @@ variable "name" {
   description = "The Lambda name."
 }
 
+variable "application" {
+  description = "The application this Lambda is provisioned for (e.g. 'dosomething-rogue')."
+}
+
 variable "environment" {
   description = "The environment for this Lambda: development, qa, or production."
 }

--- a/components/lambda_function/variables.tf
+++ b/components/lambda_function/variables.tf
@@ -1,6 +1,6 @@
 # Required variables:
 variable "name" {
-  description = "The application name."
+  description = "The Lambda name."
 }
 
 variable "environment" {

--- a/components/s3_bucket/main.tf
+++ b/components/s3_bucket/main.tf
@@ -3,6 +3,10 @@ variable "name" {
   description = "The name for this bucket (usually the application name)."
 }
 
+variable "application" {
+  description = "The application this bucket is provisioned for (e.g. 'dosomething-rogue')."
+}
+
 variable "environment" {
   description = "The environment for this bucket: development, qa, or production."
 }
@@ -98,7 +102,7 @@ resource "aws_s3_bucket" "bucket" {
   }
 
   tags = {
-    Application = var.name
+    Application = var.application
     Environment = var.environment
     Stack       = var.stack
   }

--- a/components/sqs_queue/main.tf
+++ b/components/sqs_queue/main.tf
@@ -3,6 +3,10 @@ variable "name" {
   description = "The name for this queue (usually the application name)."
 }
 
+variable "application" {
+  description = "The application this queue is provisioned for (e.g. 'dosomething-rogue')."
+}
+
 variable "environment" {
   description = "The environment for this queue: development, qa, or production."
 }
@@ -20,7 +24,7 @@ resource "aws_sqs_queue" "queue" {
   message_retention_seconds = 60 * 60 * 24 * 14 # 14 days (maximum).
 
   tags = {
-    Application = var.name
+    Application = var.application
     Environment = var.environment
     Stack       = var.stack
   }

--- a/dosomething/main.tf
+++ b/dosomething/main.tf
@@ -161,6 +161,7 @@ module "rogue_backup" {
     aws = aws.west
   }
 
+  application = "dosomething-rogue"
   name        = "dosomething-rogue-backup"
   environment = "production"
   stack       = "web"

--- a/quasar/main.tf
+++ b/quasar/main.tf
@@ -109,6 +109,7 @@ module "iam_user" {
 module "storage" {
   source = "../components/s3_bucket"
 
+  application = local.cio_export
   name        = local.cio_export
   environment = "production"
   stack       = "data"


### PR DESCRIPTION
### What's this PR do?

This pull request fixes some issues I noticed after applying #260 and reviewing resources in the AWS console:

📄 Fixes some unclear variable descriptions. 1343e3e

🚀 Adds tags to the "deploy buckets" that are used to deploy Lambda functions (previously untagged). 488cb3b


📛 Some S3, SQS, and Lambda resources have suffixes (like `dosomething-northstar-low` and `dosomething-northstar-high` queues). I've added a new `application` variable so these can be grouped as `dosomething-northstar`. 914c2c9

🏹 I've grouped all the (now deprecated) Longshot S3 buckets under a `dosomething-longshot` Application tag, rather than separate `Application=longshot-hrblock`, `Application=longshot-footlocker`, etc. 87ebde6

### How should this be reviewed?

👀

### Any background context you want to provide?

This is useful for reviewing AWS resources in the admin panel or billing views!

### Relevant tickets

References [Pivotal #173665994](https://www.pivotaltracker.com/story/show/173665994).

### Checklist

- [ ] This PR has been added to the relevant Pivotal card.
