### PR TITLE
Add Papertrail archive bucket.

### DIFF
--- a/components/log_archive/main.tf
+++ b/components/log_archive/main.tf
@@ -1,0 +1,27 @@
+variable "name" {
+  description = "The name for the archive bucket (e.g. dosomething-papertrail)."
+}
+
+resource "aws_s3_bucket" "archive" {
+  bucket = var.name
+  acl    = "private"
+
+  tags = {
+    Application = "papertrail"
+    Environment = "all"
+    Stack       = "all"
+  }
+}
+
+resource "aws_s3_bucket_policy" "papertrail_access_policy" {
+  bucket = aws_s3_bucket.archive.id
+  policy = templatefile("${path.module}/policy.json.tpl", { bucket_arn = aws_s3_bucket.archive.arn })
+}
+
+resource "aws_s3_bucket_public_access_block" "private_policy" {
+  bucket = aws_s3_bucket.archive.id
+
+  block_public_acls   = true
+  block_public_policy = true
+  ignore_public_acls  = true
+}

--- a/components/log_archive/policy.json.tpl
+++ b/components/log_archive/policy.json.tpl
@@ -1,0 +1,21 @@
+{
+    "Version": "2012-10-17",
+    "Statement": [
+      {
+        "Sid": "PapertrailLogArchive",
+        "Effect": "Allow",
+        "Principal": {
+          "AWS": [
+            "arn:aws:iam::719734659904:root"
+          ]
+        },
+        "Action": [
+          "s3:DeleteObject",
+          "s3:PutObject"
+        ],
+        "Resource": [
+          "${bucket_arn}/*"
+        ]
+      }
+    ]
+  }

--- a/dosomething/main.tf
+++ b/dosomething/main.tf
@@ -195,6 +195,14 @@ module "papertrail" {
   papertrail_destination = var.papertrail_destination
 }
 
+# We use this bucket to store longer-term Papertrail log
+# archives (e.g. for analysis with Athena).
+module "log_archive" {
+  source = "../components/log_archive"
+
+  name = "dosomething-papertrail"
+}
+
 output "papertrail_forwarder" {
   value = module.papertrail
 }


### PR DESCRIPTION
### What's this PR do?

This pull request adds an S3 bucket where we can keep our own archive of our Papertrail logs. This is could be useful if we ever need to search further than the four-week window included in our plan (via [Athena](https://aws.amazon.com/athena/)), or if we ever need to reference logs older than a year (say, to ensure a breach didn't occur if we found a security hole).

### How should this be reviewed?

This sets up a new bucket to store these zipped archive files, roughly following [Papertrail's setup guide](https://help.papertrailapp.com/kb/how-it-works/automatic-s3-archive-export/). This bucket should be private & only allow write access to Papertrail's AWS account ID.

### Any background context you want to provide?

🎋

### Relevant tickets

References [Pivotal #173253029](https://www.pivotaltracker.com/story/show/173253029).

### Checklist

- [ ] This PR has been added to the relevant Pivotal card.
