### PR TITLE
Don't block _all_ public access...

### DIFF
--- a/components/log_archive/main.tf
+++ b/components/log_archive/main.tf
@@ -21,7 +21,12 @@ resource "aws_s3_bucket_policy" "papertrail_access_policy" {
 resource "aws_s3_bucket_public_access_block" "private_policy" {
   bucket = aws_s3_bucket.archive.id
 
-  block_public_acls   = true
-  block_public_policy = true
-  ignore_public_acls  = true
+  # We don't want to risk a bug causing individual
+  # log files to be marked with "public" ACLs.
+  block_public_acls  = true
+  ignore_public_acls = true
+
+  # We need a "public" policy to grant Papertrail
+  # write access to this bucket! See: policy.json.tpl.
+  block_public_policy = false
 }


### PR DESCRIPTION
### What's this PR do?

I noticed a small issue after applying #263 - by blocking _all_ public access, I'd accidentally blocked Papertrail as well! This pull request updates these rules to allow "public" bucket policies while still disallowing per-object public permissions.

### How should this be reviewed?

:eyes:

### Any background context you want to provide?

Here's documentation on this [S3 feature](https://docs.aws.amazon.com/AmazonS3/latest/dev/access-control-block-public-access.html) and the associated [Terraform resource](https://www.terraform.io/docs/providers/aws/r/s3_bucket_public_access_block.html).

### Relevant tickets

References [Pivotal #173253029](https://www.pivotaltracker.com/story/show/173253029).

### Checklist

- [ ] This PR has been added to the relevant Pivotal card.
