### PR TITLE
Set 'LOG_CHANNEL' on our Laravel apps.

### DIFF
--- a/components/heroku_app/main.tf
+++ b/components/heroku_app/main.tf
@@ -102,8 +102,10 @@ locals {
       APP_ENV   = var.environment
       APP_DEBUG = "false"
 
-      # Configure logging for Heroku drain:
-      APP_LOG = "errorlog"
+      # Configure logging for Heroku drain. (The 'APP_LOG' environment variable
+      # is used in Laravel 5.5, and LOG_CHANNEL is used in Laravel 5.6+).
+      APP_LOG     = "errorlog"
+      LOG_CHANNEL = "errorlog"
 
       # Alongside the Trusted Proxy module, this allows us to use SSL behind
       # Heroku's load balancer. Heroku strips these headers on incoming traffic


### PR DESCRIPTION
### What's this PR do?

This pull request sets the `LOG_CHANNEL` environment variable on our Laravel applications. This is used to configure [which "stack" logs are sent to](https://laravel.com/docs/7.x/logging#configuration). On Heroku applications, we want to write to the `errorlog`, which is [how Heroku forwards logs to Papertrail](https://devcenter.heroku.com/articles/php-logging#laravel).

### How should this be reviewed?

👀

### Any background context you want to provide?

I applied this change [manually](https://dosomething.slack.com/archives/C02BBP0CU/p1595537041003100) earlier this afternoon. This change will apply the same configuration change to our other Laravel applications, in preparation for being updated to Laravel 6.0 this sprint.

### Relevant tickets

References [Pivotal #173972972](https://www.pivotaltracker.com/story/show/173972972).

### Checklist

- [ ] This PR has been added to the relevant Pivotal card.
