### PR TITLE
Use 'dosome.click' for Bertly 2.0

### DIFF
--- a/dosomething/main.tf
+++ b/dosomething/main.tf
@@ -69,8 +69,8 @@ module "bertly" {
 
   environment   = "production"
   name          = "dosomething-bertly"
-  domain        = "new.dosome.click"
-  certificate   = "*.dosome.click"
+  domain        = "dosome.click"
+  certificate   = "dosome.click"
   northstar_url = "https://identity.dosomething.org"
   logger        = module.papertrail
 }


### PR DESCRIPTION
### What's this PR do?

This pull request updates the domain mapping for Bertly 2.0 to use dosome.click.

### How should this be reviewed?

:eyes:

### Any background context you want to provide?

It's launch day! :rocket: 

### Relevant tickets

References [Pivotal #172652963](https://www.pivotaltracker.com/story/show/172652963).

### Checklist

- [ ] This PR has been added to the relevant Pivotal card.
