### PR TITLE
Create Fastly property as part of "static" app module.

### DIFF
--- a/dosomething/fastly-frontend/main.tf
+++ b/dosomething/fastly-frontend/main.tf
@@ -1,5 +1,3 @@
-variable "assets_domain" {}
-variable "assets_backend" {}
 variable "phoenix_name" {}
 variable "phoenix_backend" {}
 variable "papertrail_destination" {}

--- a/dosomething/fastly-frontend/main.tf
+++ b/dosomething/fastly-frontend/main.tf
@@ -21,29 +21,6 @@ resource "fastly_service_v1" "frontend" {
     name = "www.dosomething.org"
   }
 
-  domain {
-    name = var.assets_domain
-  }
-
-  condition {
-    type      = "REQUEST"
-    name      = "backend-assets"
-    statement = "req.http.host == \"${var.assets_domain}\""
-  }
-
-  condition {
-    type      = "CACHE"
-    name      = "cache-assets"
-    statement = "req.http.host == \"${var.assets_domain}\""
-  }
-
-  backend {
-    name              = "s3-assets.dosomething.org"
-    address           = var.assets_backend
-    request_condition = "backend-assets"
-    port              = 80
-  }
-
   backend {
     address          = var.phoenix_backend
     name             = var.phoenix_name
@@ -91,18 +68,6 @@ resource "fastly_service_v1" "frontend" {
       "text/plain",
       "text/xml",
     ]
-  }
-
-  # The S3 backend only returns a 'Vary' header if a request has a CORS header on it, which
-  # means we may accidentally cache a CORS-less response for everyone. This rule adds the
-  # expected 'Vary' if it isn't already set on the response.
-  header {
-    name            = "S3 Vary"
-    type            = "cache"
-    cache_condition = "cache-assets"
-    action          = "set"
-    destination     = "http.Vary"
-    source          = "\"Origin, Access-Control-Request-Headers, Access-Control-Request-Method\""
   }
 
   # Set headers on incoming HTTP requests, for the backend server.

--- a/dosomething/main.tf
+++ b/dosomething/main.tf
@@ -84,9 +84,6 @@ module "chompy" {
 module "fastly-frontend" {
   source = "./fastly-frontend"
 
-  assets_domain  = module.assets.domain
-  assets_backend = module.assets.backend
-
   phoenix_name    = module.phoenix.name
   phoenix_backend = module.phoenix.backend
 

--- a/voting-app/main.tf
+++ b/voting-app/main.tf
@@ -21,48 +21,6 @@ provider "fastly" {
   api_key = var.fastly_api_key
 }
 
-resource "fastly_service_v1" "voting-app" {
-  name          = "Terraform: Voting App"
-  force_destroy = true
-
-  domain {
-    name = "www.athletesgonegood.com"
-  }
-
-  gzip {
-    name = "gzip"
-
-    extensions = ["css", "js", "html", "eot", "ico", "otf", "ttf", "json"]
-
-    content_types = [
-      "text/html",
-      "application/x-javascript",
-      "text/css",
-      "application/javascript",
-      "text/javascript",
-      "application/json",
-      "application/vnd.ms-fontobject",
-      "application/x-font-opentype",
-      "application/x-font-truetype",
-      "application/x-font-ttf",
-      "application/xml",
-      "font/eot",
-      "font/opentype",
-      "font/otf",
-      "image/svg+xml",
-      "image/vnd.microsoft.icon",
-      "text/plain",
-      "text/xml",
-    ]
-  }
-
-  backend {
-    name    = "s3-www.athletesgonegood.com"
-    address = module.agg.backend
-    port    = 80
-  }
-}
-
 module "agg" {
   source = "../applications/static"
 


### PR DESCRIPTION
### What's this PR do?

This pull request extracts [assets.dosomething.org](https://assets.dosomething.org) into its own Fastly property, inside the `static` application module. This makes it easier to then re-use a single "frontend" module between all three environments (since we only create [assets.dosomething.org](https://assets.dosomething.org) in production), and simplifies our production Fastly config (to reduce the chance of accidental errors)!

### How should this be reviewed?

👀

### Any background context you want to provide?

I'm going to follow this up with a similar PR to #270 which creates a single re-usable Fastly front-end module (for [#165498108](https://www.pivotaltracker.com/story/show/165498108)), and that in turn will make it nice and simple to add security headers for [#173719273](https://www.pivotaltracker.com/story/show/173719273).

### Relevant tickets

References [Pivotal #174871199](https://www.pivotaltracker.com/story/show/174871199).

### Checklist

- [ ] This PR has been added to the relevant Pivotal card.
