### PR TITLE
Don't force SSL on Athletes Gone Good.

### DIFF
--- a/applications/static/main.tf
+++ b/applications/static/main.tf
@@ -10,6 +10,11 @@ variable "stack" {
   description = "The 'stack' for this bucket: web, sms, backend, data."
 }
 
+variable "force_ssl" {
+  description = "Should we force all traffic to SSL for this app?"
+  default     = true
+}
+
 resource "fastly_service_v1" "cdn" {
   name          = "Terraform: ${var.domain}"
   force_destroy = true
@@ -26,7 +31,7 @@ resource "fastly_service_v1" "cdn" {
 
   request_setting {
     name      = "Force SSL"
-    force_ssl = true
+    force_ssl = var.force_ssl
   }
 
   gzip {

--- a/voting-app/main.tf
+++ b/voting-app/main.tf
@@ -27,5 +27,7 @@ module "agg" {
   domain      = "www.athletesgonegood.com"
   environment = "production"
   stack       = "web"
+
+  force_ssl = false # We don't have an SSL certificate for this domain.
 }
 


### PR DESCRIPTION
### What's this PR do?

This pull request adds a toggle for whether or not to force SSL on a `static` application. This is a quick follow-up from #271 when I realized that we don't have an SSL certificate for [athletesgonegood.com](http://www.athletesgonegood.com) and so we can't force SSL there.

### How should this be reviewed?

👀

### Any background context you want to provide?

In general, we of course want to force SSL! However, some old domains we keep around for historical purposes, like [athletesgonegood.com](http://www.athletesgonegood.com) aren't worth paying Fastly for a certificate for.

### Relevant tickets

References [Pivotal #]().

### Checklist

- [ ] This PR has been added to the relevant Pivotal card.
