### PR TITLE
Add standard headers to frontend & backend services.

### DIFF
--- a/components/fastly_backends/main.tf
+++ b/components/fastly_backends/main.tf
@@ -14,10 +14,38 @@ variable "papertrail_destination" {
 }
 
 locals {
-  headers = {
+  request_headers = {
+    # Provide geolocation information to web servers:
     "X-Fastly-Country-Code" = "client.geo.country_code",
     "X-Fastly-Region-Code"  = "client.geo.region",
     "X-Fastly-Postal-Code"  = "client.geo.postal_code",
+  }
+
+  response_headers = {
+    # Expose geolocation information in debug headers:
+    "X-Fastly-Country-Code" = "client.geo.country_code",
+    "X-Fastly-Region-Code"  = "client.geo.region",
+    "X-Fastly-Postal-Code"  = "client.geo.postal_code",
+
+    # Ensures that we don't leak sensitive items from URLs in Referrer headers: we will
+    # send full URL if same-origin and HTTPS, origin-only (e.g. 'www.dosomething.org')
+    # when crossing domains, and nothing at all when going to HTTP.
+    "Referrer-Policy" = "\"strict-origin-when-cross-origin\""
+
+    # Enforce HTTPS for all traffic (TODO: https://www.pivotaltracker.com/story/show/174911098)
+    "Strict-Transport-Security" = "\"max-age=300; includeSubDomains\"" # 5 minutes.
+
+    # Prevent sniffing content types:
+    "X-Content-Type-Options" = "\"nosniff\""
+
+    # Restrict this application from being embedded as an iframe on
+    # third-party domains, to prevent click-jacking attacks:
+    "X-Frame-Options" = "\"SAMEORIGIN\""
+
+    # Enable XSS filtering in some browsers. This should be
+    # replaced by a strong Content Security Policy in the future.
+    # TODO: https://www.pivotaltracker.com/story/show/174911196
+    "X-XSS-Protection" = "\"1\""
   }
 }
 
@@ -143,9 +171,8 @@ resource "fastly_service_v1" "backends" {
     ]
   }
 
-  # Set headers on incoming HTTP requests, for the backend server.
   dynamic "header" {
-    for_each = local.headers
+    for_each = local.request_headers
 
     content {
       name        = "${header.key} (Request)"
@@ -156,9 +183,8 @@ resource "fastly_service_v1" "backends" {
     }
   }
 
-  # And set "debug" headers on HTTP responses, for inspection.
   dynamic "header" {
-    for_each = local.headers
+    for_each = local.response_headers
 
     content {
       name        = "${header.key} (Response)"


### PR DESCRIPTION
### What's this PR do?

This pull request adds standard security headers to our Fastly properties - ensuring that any application behind our CDN gets these applied! I've also separated out the variables where we set request & response headers (since unlike geolocation headers, we don't need these to be applied in both places).

### How should this be reviewed?

You can see the changes made to the list of headers in our frontend & backend service components. These will then get applied consistently to all six properties when we merge & apply this.

### Any background context you want to provide?

🔒

### Relevant tickets

References [Pivotal #173719273](https://www.pivotaltracker.com/story/show/173719273).

### Checklist

- [ ] This PR has been added to the relevant Pivotal card.
