### PR TITLE
Allow embedding page at end of voter registration flow.

### DIFF
--- a/components/fastly_frontend/main.tf
+++ b/components/fastly_frontend/main.tf
@@ -134,6 +134,24 @@ resource "fastly_service_v1" "frontend" {
     }
   }
 
+  # Override: Remove 'X-Frame-Options' on URL(s) that we do
+  # want to allow embedding from external domains:
+  condition {
+    type      = "RESPONSE"
+    name      = "allow-embed"
+    statement = "req.url ~ \"^/us/about/voter-registration-thank-you\""
+  }
+
+  header {
+    name               = "Allow Embed on Path(s)"
+    type               = "response"
+    action             = "delete"
+    destination        = "http.X-Frame-Options"
+    response_condition = "allow-embed"
+    priority           = 200 # This needs to happen after we add the response header, above.
+  }
+
+  # Redirect any HTTP traffic to HTTPS:
   request_setting {
     name      = "Force SSL"
     force_ssl = true


### PR DESCRIPTION
### What's this PR do?

This pull request removes the `X-Frame-Options` header from the `/us/about/voter-registration-thank-you` page embedded on the Rock The Vote "Thank You" page. This should allow this page to be embedded on this (and any other) third-party domains, while keeping protection enabled on other URLs.


### How should this be reviewed?

👀

### Any background context you want to provide?

🇺🇸 

### Relevant tickets

References [Pivotal #174971084](https://www.pivotaltracker.com/story/show/174971084).

### Checklist

- [ ] This PR has been added to the relevant Pivotal card.
