### PR TITLE
Removing backup window to allow RDS to manage this

### DIFF
--- a/components/postgresql_warehouse/main.tf
+++ b/components/postgresql_warehouse/main.tf
@@ -178,7 +178,6 @@ resource "aws_db_instance" "quasar" {
   engine_version                  = var.engine_version
   allow_major_version_upgrade     = true
   backup_retention_period         = local.backup_retention # See above!
-  backup_window                   = "06:00-07:00"          # 1-2am ET.
   instance_class                  = var.instance_class
   name                            = var.database_name
   username                        = var.username


### PR DESCRIPTION
### What's this PR do?

This pull request removes the backup window variable to allow RDS to manage this. The `apply` errored out because the window overlaps the maintenance window. At the moment we don't need to have fine-grained control over that, and we can just let the existing window stand.

### How should this be reviewed?

...

### Any background context you want to provide?

https://app.terraform.io/app/dosomething/workspaces/quasar/runs/run-Cvt1FajKA1u7BvNn

### Relevant tickets

References [Pivotal #174829369](https://www.pivotaltracker.com/story/show/174829369).

### Checklist

- [ ] This PR has been added to the relevant Pivotal card.
