### PR TITLE
Adding quasar s3 role and policy

### DIFF
--- a/components/quasar_s3_export_role/iam-policy.json.tpl
+++ b/components/quasar_s3_export_role/iam-policy.json.tpl
@@ -19,8 +19,7 @@
               "s3:DeleteObject*"
           ],
           "Resource": [
-              "arn:aws:s3:::dosomething-archive",
-              "arn:aws:s3:::dosomething-archive/*"
+            "${bucket_arn}/*"
           ]
       }
   ]

--- a/components/quasar_s3_export_role/iam-policy.json.tpl
+++ b/components/quasar_s3_export_role/iam-policy.json.tpl
@@ -1,0 +1,27 @@
+{
+  "Version": "2012-10-17",
+  "Statement": [
+      {
+          "Effect": "Allow",
+          "Action": [
+              "s3:ListBucket",
+              "s3:GetBucketLocation"
+          ],
+          "Resource": [
+              "arn:aws:s3:::*"
+          ]
+      },
+      {
+          "Effect": "Allow",
+          "Action": [
+              "s3:PutObject*",
+              "s3:GetObject*",
+              "s3:DeleteObject*"
+          ],
+          "Resource": [
+              "arn:aws:s3:::dosomething-archive",
+              "arn:aws:s3:::dosomething-archive/*"
+          ]
+      }
+  ]
+}

--- a/components/quasar_s3_export_role/main.tf
+++ b/components/quasar_s3_export_role/main.tf
@@ -52,7 +52,7 @@ data "aws_iam_policy_document" "quasar_s3_export_role" {
 
 resource "aws_iam_policy" "policy" {
   name   = "ExportPolicy"
-  policy = templatefile("${path.module}/policy.json.tpl", { bucket_arn = aws_s3_bucket.dosomething_quasar_archive.arn })
+  policy = templatefile("${path.module}/iam-policy.json.tpl", { bucket_arn = aws_s3_bucket.dosomething_quasar_archive.arn })
 }
 
 resource "aws_iam_role" "role" {

--- a/components/quasar_s3_export_role/main.tf
+++ b/components/quasar_s3_export_role/main.tf
@@ -22,7 +22,7 @@ data "aws_iam_policy_document" "quasar_s3_export_role" {
 
 resource "aws_iam_policy" "policy" {
   name   = "ExportPolicy"
-  policy = templatefile("${path.module}/iam-policy.json.tpl", { bucket_arn = aws_s3_bucket.dosomething_quasar_archive.arn })
+  policy = templatefile("${path.module}/iam-policy.json.tpl", { bucket_arn = var.arn })
 }
 
 resource "aws_iam_role" "role" {

--- a/components/quasar_s3_export_role/main.tf
+++ b/components/quasar_s3_export_role/main.tf
@@ -1,0 +1,28 @@
+data "aws_iam_policy_document" "quasar_s3_export_role" {
+  statement {
+    effect = "Allow"
+    actions = ["sts:AssumeRole"]
+    principals {
+      type        = "Service"
+      identifiers = ["export.rds.amazonaws.com"]
+    }
+  }
+}
+
+resource "aws_iam_policy" "policy" {
+  name = "ExportPolicy"
+  policy = templatefile("${path.module}/iam-policy.json.tpl", {
+    bucket_arn = var.bucket.arn
+  })
+}
+
+resource "aws_iam_role" "role" {
+  name               = "rds-s3-export-role"
+  description        = "Role for exporting Quasar RDS snapshots to S3."
+  assume_role_policy = data.aws_iam_policy_document.quasar_s3_export_role.json
+}
+
+resource "aws_iam_role_policy_attachment" "attachment" {
+  role       = "${aws_iam_role.role.name}"
+  policy_arn = "${aws_iam_policy.policy.arn}"
+}

--- a/components/quasar_s3_export_role/main.tf
+++ b/components/quasar_s3_export_role/main.tf
@@ -1,3 +1,44 @@
+resource "aws_s3_bucket" "dosomething_quasar_archive" {
+  bucket = "dosomething-quasar-archive"
+  acl    = "private"
+
+  lifecycle_rule {
+    id      = "archive"
+    enabled = true
+
+    prefix = "archive/"
+
+    tags = {
+      "rule" = "archive"
+    }
+
+    transition {
+      days          = 30
+      storage_class = "STANDARD_IA" # or "ONEZONE_IA"
+    }
+
+    transition {
+      days          = 30
+      storage_class = "GLACIER"
+    }
+
+    expiration {
+      days = 60
+    }
+
+  }
+}
+
+resource "aws_s3_bucket_public_access_block" "private_policy" {
+  bucket = aws_s3_bucket.dosomething_quasar_archive.id
+
+  # We don't want to risk a bug causing individual
+  # log files to be marked with "public" ACLs.
+  block_public_acls  = true
+  ignore_public_acls = true
+
+}
+
 data "aws_iam_policy_document" "quasar_s3_export_role" {
   statement {
     effect  = "Allow"
@@ -11,7 +52,7 @@ data "aws_iam_policy_document" "quasar_s3_export_role" {
 
 resource "aws_iam_policy" "policy" {
   name   = "ExportPolicy"
-  policy = templatefile("${path.module}/iam-policy.json.tpl")
+  policy = templatefile("${path.module}/policy.json.tpl", { bucket_arn = aws_s3_bucket.dosomething_quasar_archive.arn })
 }
 
 resource "aws_iam_role" "role" {

--- a/components/quasar_s3_export_role/main.tf
+++ b/components/quasar_s3_export_role/main.tf
@@ -1,14 +1,3 @@
-resource "aws_s3_bucket_public_access_block" "private_policy" {
-  bucket = aws_s3_bucket.dosomething_quasar_archive.id
-
-  # We don't want to risk a bug causing individual
-  # archived files to be marked with "public" ACLs.
-  block_public_acls  = true
-  ignore_public_acls = true
-
-  block_public_policy = true
-}
-
 data "aws_iam_policy_document" "quasar_s3_export_role" {
   statement {
     effect  = "Allow"

--- a/components/quasar_s3_export_role/main.tf
+++ b/components/quasar_s3_export_role/main.tf
@@ -10,10 +10,8 @@ data "aws_iam_policy_document" "quasar_s3_export_role" {
 }
 
 resource "aws_iam_policy" "policy" {
-  name = "ExportPolicy"
-  policy = templatefile("${path.module}/iam-policy.json.tpl", {
-    bucket_arn = var.bucket.arn
-  })
+  name   = "ExportPolicy"
+  policy = templatefile("${path.module}/iam-policy.json.tpl")
 }
 
 resource "aws_iam_role" "role" {

--- a/components/quasar_s3_export_role/main.tf
+++ b/components/quasar_s3_export_role/main.tf
@@ -1,42 +1,12 @@
-resource "aws_s3_bucket" "dosomething_quasar_archive" {
-  bucket = "dosomething-quasar-archive"
-  acl    = "private"
-
-  lifecycle_rule {
-    id      = "archive"
-    enabled = true
-
-    prefix = "archive/"
-
-    tags = {
-      "rule" = "archive"
-    }
-
-    transition {
-      days          = 30
-      storage_class = "STANDARD_IA" # or "ONEZONE_IA"
-    }
-
-    transition {
-      days          = 30
-      storage_class = "GLACIER"
-    }
-
-    expiration {
-      days = 60
-    }
-
-  }
-}
-
 resource "aws_s3_bucket_public_access_block" "private_policy" {
   bucket = aws_s3_bucket.dosomething_quasar_archive.id
 
   # We don't want to risk a bug causing individual
-  # log files to be marked with "public" ACLs.
+  # archived files to be marked with "public" ACLs.
   block_public_acls  = true
   ignore_public_acls = true
 
+  block_public_policy = true
 }
 
 data "aws_iam_policy_document" "quasar_s3_export_role" {

--- a/components/quasar_s3_export_role/main.tf
+++ b/components/quasar_s3_export_role/main.tf
@@ -1,6 +1,6 @@
 data "aws_iam_policy_document" "quasar_s3_export_role" {
   statement {
-    effect = "Allow"
+    effect  = "Allow"
     actions = ["sts:AssumeRole"]
     principals {
       type        = "Service"

--- a/components/quasar_s3_export_role/outputs.tf
+++ b/components/quasar_s3_export_role/outputs.tf
@@ -1,0 +1,4 @@
+output "role_arn" {
+  description = "The Quasar Export Role ARN."
+  value       = aws_iam_role.role.arn
+}

--- a/components/quasar_s3_export_role/variables.tf
+++ b/components/quasar_s3_export_role/variables.tf
@@ -1,0 +1,3 @@
+variable "arn" {
+  description = "The ARN for the Quasar archive s3 bucket."
+}

--- a/quasar/main.tf
+++ b/quasar/main.tf
@@ -135,5 +135,5 @@ module "quasar_archive" {
 module "rds_export_role" {
   source = "../components/quasar_s3_export_role"
 
-  arn = module.quasar_archive.role_arn
+  arn = module.quasar_archive.bucket.arn
 }

--- a/quasar/main.tf
+++ b/quasar/main.tf
@@ -119,7 +119,42 @@ module "storage" {
   private    = true
 }
 
-module "quasar_s3_export_role" {
+module "quasar_archive" {
+  source = "../components/s3_bucket"
+
+  application = "dosomething-quasar"
+  name        = "dosomething-quasar-archive"
+  environment = "production"
+  stack       = "data"
+
+  versioning = true
+  archived   = true
+  private    = true
+
+  lifecycle_rule {
+    id      = "archive"
+    enabled = true
+
+    prefix = "archive/"
+
+    tags = {
+      "rule" = "archive"
+    }
+
+    transition {
+      days          = 30
+      storage_class = "STANDARD_IA" # or "ONEZONE_IA"
+    }
+
+    transition {
+      days          = 45
+      storage_class = "GLACIER"
+    }
+  }
+}
+
+module "rds_export_role" {
   source = "../components/quasar_s3_export_role"
 
+  arn = module.quasar_archive.arn
 }

--- a/quasar/main.tf
+++ b/quasar/main.tf
@@ -122,5 +122,4 @@ module "storage" {
 module "quasar_s3_export_role" {
   source = "../components/quasar_s3_export_role"
 
-  bucket      = "dosomething-archive"
 }

--- a/quasar/main.tf
+++ b/quasar/main.tf
@@ -52,7 +52,7 @@ module "vpc" {
   source = "../components/quasar_vpc"
 }
 
-# Trying to setup parameter groups necessry to remove existing 
+# Trying to setup parameter groups necessry to remove existing
 # longform values above and source from components/postgresql_instance module.
 module "warehouse" {
   source = "../components/postgresql_warehouse"
@@ -117,4 +117,10 @@ module "storage" {
   user       = module.iam_user.name
   versioning = true
   private    = true
+}
+
+module "quasar_s3_export_role" {
+  source = "../components/quasar_s3_export_role"
+
+  bucket      = "dosomething-archive"
 }

--- a/quasar/main.tf
+++ b/quasar/main.tf
@@ -135,5 +135,5 @@ module "quasar_archive" {
 module "rds_export_role" {
   source = "../components/quasar_s3_export_role"
 
-  arn = module.quasar_archive.arn
+  arn = module.quasar_archive.role_arn
 }

--- a/quasar/main.tf
+++ b/quasar/main.tf
@@ -130,27 +130,6 @@ module "quasar_archive" {
   versioning = true
   archived   = true
   private    = true
-
-  lifecycle_rule {
-    id      = "archive"
-    enabled = true
-
-    prefix = "archive/"
-
-    tags = {
-      "rule" = "archive"
-    }
-
-    transition {
-      days          = 30
-      storage_class = "STANDARD_IA" # or "ONEZONE_IA"
-    }
-
-    transition {
-      days          = 45
-      storage_class = "GLACIER"
-    }
-  }
 }
 
 module "rds_export_role" {


### PR DESCRIPTION
### What's this PR do?

This PR creates the IAM role and policy for the RDS Quasar snapshots to be stored in S3, and a new bucket to store the archived snapshots.

### How should this be reviewed?

...

### Any background context you want to provide?

...

### Relevant tickets

References [Pivotal #174829369](https://www.pivotaltracker.com/story/show/174829369).

### Checklist

- [x] This PR has been added to the relevant Pivotal card.
