### PR TITLE
Configure Gambit URL & credentials for this app.

### DIFF
--- a/dosomething-qa/main.tf
+++ b/dosomething-qa/main.tf
@@ -129,6 +129,7 @@ module "rogue" {
   domain        = "activity-qa.dosomething.org"
   pipeline      = var.rogue_pipeline
   northstar_url = "https://identity-qa.dosomething.org"
+  gambit_url    = "https://gambit-conversations-staging.herokuapp.com"
   graphql_url   = "https://graphql-qa.dosomething.org/graphql"
   blink_url     = "https://blink-staging.dosomething.org/api/"
 

--- a/dosomething/main.tf
+++ b/dosomething/main.tf
@@ -165,6 +165,7 @@ module "rogue" {
   domain                 = "activity.dosomething.org"
   pipeline               = var.rogue_pipeline
   northstar_url          = "https://identity.dosomething.org"
+  gambit_url             = "https://gambit-conversations-prod.herokuapp.com"
   graphql_url            = "https://graphql.dosomething.org/graphql"
   blink_url              = "https://blink.dosomething.org/api/"
   papertrail_destination = var.papertrail_destination


### PR DESCRIPTION
### What's this PR do?

This pull request configures the required `GAMBIT_URL`, `GAMBIT_USERNAME`, and `GAMBIT_PASSWORD` environment variables for the queue job introduced in DoSomething/rogue#1128. It also sets the `DS_ENABLE_BLINK`, `DS_ENABLE_CUSTOMER_IO`, and `DS_ENABLE_GAMBIT_RELAY` feature flags based on environment.

### How should this be reviewed?

Does this set the right variables? Do the plans succeed?

### Any background context you want to provide?

This application is taking some responsibility (to talk directly to Gambit) away from Blink. We want to make these changes here in Terraform so that they're easy to replicate if we need to rebuild any of these environments from scratch, and so that we don't accidentally apply the wrong settings if making these changes by hand.

### Relevant tickets

References [Pivotal #174827024](https://www.pivotaltracker.com/story/show/174827024).

### Checklist

- [ ] This PR has been added to the relevant Pivotal card.
