### PR TITLE
Increase 'Strict-Transport-Security' duration.

### DIFF
--- a/components/fastly_backends/main.tf
+++ b/components/fastly_backends/main.tf
@@ -32,7 +32,7 @@ locals {
     # when crossing domains, and nothing at all when going to HTTP.
     "Referrer-Policy" = "\"strict-origin-when-cross-origin\""
 
-    # Enforce HTTPS for all traffic (TODO: https://www.pivotaltracker.com/story/show/174911098)
+    # Enforce HTTPS for all traffic (TODO: https://www.pivotaltracker.com/story/show/175288875)
     "Strict-Transport-Security" = "\"max-age=604800; includeSubDomains\"" # 1 week.
 
     # Prevent sniffing content types:

--- a/components/fastly_backends/main.tf
+++ b/components/fastly_backends/main.tf
@@ -33,7 +33,7 @@ locals {
     "Referrer-Policy" = "\"strict-origin-when-cross-origin\""
 
     # Enforce HTTPS for all traffic (TODO: https://www.pivotaltracker.com/story/show/174911098)
-    "Strict-Transport-Security" = "\"max-age=300; includeSubDomains\"" # 5 minutes.
+    "Strict-Transport-Security" = "\"max-age=604800; includeSubDomains\"" # 1 week.
 
     # Prevent sniffing content types:
     "X-Content-Type-Options" = "\"nosniff\""

--- a/components/fastly_frontend/main.tf
+++ b/components/fastly_frontend/main.tf
@@ -37,7 +37,7 @@ locals {
     "Referrer-Policy" = "\"strict-origin-when-cross-origin\""
 
     # Enforce HTTPS for all traffic (TODO: https://www.pivotaltracker.com/story/show/174911098)
-    "Strict-Transport-Security" = "\"max-age=300; includeSubDomains\"" # 5 minutes.
+    "Strict-Transport-Security" = "\"max-age=604800; includeSubDomains\"" # 1 week.
 
     # Prevent sniffing content types:
     "X-Content-Type-Options" = "\"nosniff\""

--- a/components/fastly_frontend/main.tf
+++ b/components/fastly_frontend/main.tf
@@ -36,7 +36,7 @@ locals {
     # when crossing domains, and nothing at all when going to HTTP.
     "Referrer-Policy" = "\"strict-origin-when-cross-origin\""
 
-    # Enforce HTTPS for all traffic (TODO: https://www.pivotaltracker.com/story/show/174911098)
+    # Enforce HTTPS for all traffic (TODO: https://www.pivotaltracker.com/story/show/175288875)
     "Strict-Transport-Security" = "\"max-age=604800; includeSubDomains\"" # 1 week.
 
     # Prevent sniffing content types:


### PR DESCRIPTION
### What's this PR do?

This pull request increases our `Strict-Transport-Security` duration to 1 week. This means that once a user visits our website (and their browser sees this header), they'll _only_ be able to load `*.dosomething.org` sites over HTTPS. (For [the past few weeks](https://github.com/DoSomething/infrastructure/pull/274/files/b34a1bd79e7d3b5b8930408434d07158a84c68e4#r492348243), HTTPS would only be forced for the following 5 minutes after a user visited the site.)

### How should this be reviewed?

👀

### Any background context you want to provide?

We're slowly ramping this up over time to make sure that we don't accidentally cause issues we can't fix (since the setting is stored on user's local machines and therefore there's no way to "undo" this aside from waiting the duration specified).

### Relevant tickets

References [Pivotal #174911098](https://www.pivotaltracker.com/story/show/174911098).

### Checklist

- [ ] This PR has been added to the relevant Pivotal card.
