### PR TITLE
Add DS_ENABLE_CUSTOMER_IO flag to Northstar.

### DIFF
--- a/applications/northstar/main.tf
+++ b/applications/northstar/main.tf
@@ -91,6 +91,7 @@ locals {
   feature_config_vars = {
     DS_ENABLE_PASSWORD_GRANT = false
     DS_ENABLE_RATE_LIMITING  = true
+    DS_ENABLE_CUSTOMER_IO    = var.environment != "development"
   }
 
   # This application is part of our backend stack.


### PR DESCRIPTION
### What's this PR do?

This pull request simply adds the `DS_ENABLE_CUSTOMER_IO` feature flag to Northstar, so it can replace the old (and no longer accurately named) `DS_ENABLE_BLINK` feature flag [like we've done in Rogue](https://github.com/DoSomething/infrastructure/blob/8864abc714907d9ba735429c159b290016270e98/applications/rogue/main.tf#L109).

### How should this be reviewed?

👀

### Any background context you want to provide?

We had previously not been handling this feature flag in Terraform, but it's a good time to start!

### Relevant tickets

N/A

### Checklist

- [ ] This PR has been added to the relevant Pivotal card.
