### PR TITLE
Use Northstar for Phoenix & GraphQL activity APIs.

### DIFF
--- a/applications/graphql/main.tf
+++ b/applications/graphql/main.tf
@@ -9,6 +9,10 @@ variable "name" {
   description = "The application name."
 }
 
+variable "rogue_url" {
+  description = "The URL for our activity API."
+}
+
 # Optional variables:
 variable "domain" {
   description = "The domain this application will be accessible at, e.g. graphql-lambda.dosomething.org"
@@ -107,6 +111,9 @@ module "app" {
     # TODO: Remove Gambit Conversations vars once https://github.com/DoSomething/graphql/pull/57 is deployed everywhere.
     "${upper(local.gambit_env)}_GAMBIT_CONVERSATIONS_USER" = data.aws_ssm_parameter.gambit_username.value
     "${upper(local.gambit_env)}_GAMBIT_CONVERSATIONS_PASS" = data.aws_ssm_parameter.gambit_password.value
+
+    # Override Rogue URL for this environment:
+    "${local.ENV}_ROGUE_URL" = var.rogue_url
 
     AIRTABLE_API_KEY = data.aws_ssm_parameter.airtable_api_key.value
 

--- a/applications/phoenix/main.tf
+++ b/applications/phoenix/main.tf
@@ -35,6 +35,10 @@ variable "papertrail_destination" {
   description = "The Papertrail log destination for this application."
 }
 
+variable "rogue_url" {
+  description = "The URL for our activity API."
+}
+
 # Optional variables:
 variable "web_size" {
   # See usage below for default fallback. <https://stackoverflow.com/a/51758050/811624>
@@ -80,6 +84,10 @@ locals {
     CONTENTFUL_CACHE           = false == var.use_contentful_preview_api
   }
 
+  extra_config_vars = {
+    ROGUE_URL = var.rogue_url
+  }
+
   # This application is part of our frontend stack.
   stack = "web"
 }
@@ -93,7 +101,7 @@ module "app" {
   pipeline    = var.pipeline
   environment = var.environment
 
-  config_vars = merge(module.database.config_vars, local.contentful_config_vars)
+  config_vars = merge(module.database.config_vars, local.contentful_config_vars, local.extra_config_vars)
 
   web_size = coalesce(
     var.web_size,

--- a/dosomething-dev/main.tf
+++ b/dosomething-dev/main.tf
@@ -91,7 +91,7 @@ module "graphql" {
   name        = "dosomething-graphql-dev"
   domain      = "graphql-dev.dosomething.org"
   logger      = module.papertrail
-  rogue_url   = "https://activity-dev.dosomething.org"
+  rogue_url   = "https://identity-dev.dosomething.org"
 }
 
 module "northstar" {
@@ -112,7 +112,7 @@ module "phoenix" {
   name                   = "dosomething-phoenix-dev"
   domain                 = "dev.dosomething.org"
   pipeline               = var.phoenix_pipeline
-  rogue_url              = "https://activity-dev.dosomething.org"
+  rogue_url              = "https://identity-dev.dosomething.org"
   papertrail_destination = var.papertrail_destination
 }
 

--- a/dosomething-dev/main.tf
+++ b/dosomething-dev/main.tf
@@ -112,6 +112,7 @@ module "phoenix" {
   name                   = "dosomething-phoenix-dev"
   domain                 = "dev.dosomething.org"
   pipeline               = var.phoenix_pipeline
+  rogue_url              = "https://activity-dev.dosomething.org"
   papertrail_destination = var.papertrail_destination
 }
 

--- a/dosomething-dev/main.tf
+++ b/dosomething-dev/main.tf
@@ -91,6 +91,7 @@ module "graphql" {
   name        = "dosomething-graphql-dev"
   domain      = "graphql-dev.dosomething.org"
   logger      = module.papertrail
+  rogue_url   = "https://activity-dev.dosomething.org"
 }
 
 module "northstar" {

--- a/dosomething-qa/main.tf
+++ b/dosomething-qa/main.tf
@@ -97,7 +97,7 @@ module "graphql" {
   name        = "dosomething-graphql-qa"
   domain      = "graphql-qa.dosomething.org"
   logger      = module.papertrail
-  rogue_url   = "https://activity-qa.dosomething.org"
+  rogue_url   = "https://identity-qa.dosomething.org"
 }
 
 module "northstar" {
@@ -119,7 +119,7 @@ module "phoenix" {
   name        = "dosomething-phoenix-qa"
   domain      = "qa.dosomething.org"
   pipeline    = var.phoenix_pipeline
-  rogue_url   = "https://activity-qa.dosomething.org"
+  rogue_url   = "https://identity-qa.dosomething.org"
 
   papertrail_destination = var.papertrail_destination
 }

--- a/dosomething-qa/main.tf
+++ b/dosomething-qa/main.tf
@@ -97,6 +97,7 @@ module "graphql" {
   name        = "dosomething-graphql-qa"
   domain      = "graphql-qa.dosomething.org"
   logger      = module.papertrail
+  rogue_url   = "https://activity-qa.dosomething.org"
 }
 
 module "northstar" {

--- a/dosomething-qa/main.tf
+++ b/dosomething-qa/main.tf
@@ -119,6 +119,7 @@ module "phoenix" {
   name        = "dosomething-phoenix-qa"
   domain      = "qa.dosomething.org"
   pipeline    = var.phoenix_pipeline
+  rogue_url   = "https://activity-qa.dosomething.org"
 
   papertrail_destination = var.papertrail_destination
 }

--- a/dosomething/main.tf
+++ b/dosomething/main.tf
@@ -128,6 +128,7 @@ module "phoenix" {
   name                   = "dosomething-phoenix"
   domain                 = "www.dosomething.org"
   pipeline               = var.phoenix_pipeline
+  rogue_url              = "https://activity.dosomething.org"
   papertrail_destination = var.papertrail_destination
 }
 

--- a/dosomething/main.tf
+++ b/dosomething/main.tf
@@ -106,7 +106,7 @@ module "graphql" {
   name        = "dosomething-graphql"
   domain      = "graphql.dosomething.org"
   logger      = module.papertrail
-  rogue_url   = "https://activity.dosomething.org"
+  rogue_url   = "https://identity.dosomething.org"
 }
 
 module "northstar" {
@@ -128,7 +128,7 @@ module "phoenix" {
   name                   = "dosomething-phoenix"
   domain                 = "www.dosomething.org"
   pipeline               = var.phoenix_pipeline
-  rogue_url              = "https://activity.dosomething.org"
+  rogue_url              = "https://identity.dosomething.org"
   papertrail_destination = var.papertrail_destination
 }
 

--- a/dosomething/main.tf
+++ b/dosomething/main.tf
@@ -106,6 +106,7 @@ module "graphql" {
   name        = "dosomething-graphql"
   domain      = "graphql.dosomething.org"
   logger      = module.papertrail
+  rogue_url   = "https://activity.dosomething.org"
 }
 
 module "northstar" {

--- a/dosomething/main.tf
+++ b/dosomething/main.tf
@@ -141,6 +141,7 @@ module "phoenix_preview" {
   web_size               = "Standard-1x"
   pipeline               = var.phoenix_pipeline
   papertrail_destination = var.papertrail_destination
+  rogue_url              = "https://identity.dosomething.org"
 
   use_contentful_preview_api = true
 }


### PR DESCRIPTION
### What's this PR do?

This pull request updates Phoenix & GraphQL to use Northstar for activity endpoints! ✨

### How should this be reviewed?

Did I typo any environment variable names or URLs? For reference, these environment variables are used [here](https://github.com/DoSomething/graphql/blob/master/config/services.js) and [here](https://github.com/DoSomething/graphql/blob/master/config/services.js).

I'll apply this in our development & QA environments first, and test all of Phoenix's user flows to make sure everything works before promoting this to production. I'll also change Chompy & Gambit's `ROGUE_URL` to point to Northstar as well, but those applications aren't managed by Terraform.

### Any background context you want to provide?

After this change is made, we'll be unblocked from working on ~Rogue~ Northstar's activity endpoints. We'll still use Rogue for administrative tasks until we finish moving those over to Northstar in [#176911792](https://www.pivotaltracker.com/story/show/176911792).

We'll also, of course, want a better URL for this service than `identity`. We'll tackle that as a follow-up in [#176851320](https://www.pivotaltracker.com/story/show/176851320).

### Relevant tickets

References [Pivotal #176851319](https://www.pivotaltracker.com/story/show/176851319).

### Checklist

- [ ] This PR has been added to the relevant Pivotal card.
