### PR TITLE
Disconnect Rogue/Aurora & redirect to Northstar.

### DIFF
--- a/applications/rogue/main.tf
+++ b/applications/rogue/main.tf
@@ -134,10 +134,8 @@ module "app" {
   pipeline    = var.pipeline
   environment = var.environment
 
-  web_size = var.environment == "production" ? "Standard-2x" : "Standard-1x"
-
-  # We use autoscaling in production, so don't try to manage dynos there.
-  ignore_web = var.environment == "production"
+  web_scale   = 0
+  queue_scale = 0
 
   config_vars = merge(
     module.database.config_vars,
@@ -145,9 +143,6 @@ module "app" {
     module.iam_user.config_vars,
     local.extra_config_vars,
   )
-
-  # We don't run a queue process on development right now. @TODO: Should we?
-  queue_scale = var.environment == "development" ? 0 : 1
 
   with_redis = true
 

--- a/dosomething-dev/main.tf
+++ b/dosomething-dev/main.tf
@@ -78,7 +78,6 @@ module "fastly-backend" {
 
   applications = [
     module.northstar,
-    module.rogue,
   ]
 
   papertrail_destination = var.papertrail_destination_fastly

--- a/dosomething-qa/main.tf
+++ b/dosomething-qa/main.tf
@@ -84,7 +84,6 @@ module "fastly-backend" {
 
   applications = [
     module.northstar,
-    module.rogue,
   ]
 
   papertrail_destination = var.papertrail_destination_fastly

--- a/dosomething/main.tf
+++ b/dosomething/main.tf
@@ -92,7 +92,6 @@ module "fastly-backend" {
 
   applications = [
     module.northstar,
-    module.rogue,
     module.phoenix_preview # Not technically a backend... but placed here for simplicity.
   ]
 

--- a/redirects/main.tf
+++ b/redirects/main.tf
@@ -173,6 +173,30 @@ resource "fastly_service_v1" "redirects2" {
     name = "www-preview.dosomething.org"
   }
 
+  domain {
+    name = "activity.dosomething.org"
+  }
+
+  domain {
+    name = "activity-qa.dosomething.org"
+  }
+
+  domain {
+    name = "activity-dev.dosomething.org"
+  }
+
+  domain {
+    name = "admin.dosomething.org"
+  }
+
+  domain {
+    name = "admin-qa.dosomething.org"
+  }
+
+  domain {
+    name = "admin-dev.dosomething.org"
+  }
+
   # Note: Fastly requires at least one backend per service,
   # so our AWS HAProxy instance is included here.
   backend {

--- a/redirects/redirects_table.vcl
+++ b/redirects/redirects_table.vcl
@@ -35,10 +35,20 @@ table redirects {
   "www-preview.dosomething.org": "https://preview.dosomething.org",
   "www-dev.dosomething.org": "https://dev.dosomething.org",
 
-  # Rogue:
+  # Rogue (old):
   "rogue.dosomething.org": "https://activity.dosomething.org",
   "rogue-thor.dosomething.org": "https://activity-qa.dosomething.org",
   "rogue-qa.dosomething.org": "https://activity-dev.dosomething.org",
+
+  # Rogue:
+  "activity.dosomething.org": "https://identity.dosomething.org/admin",
+  "activity-qa.dosomething.org": "https://identity-qa.dosomething.org/admin",
+  "activity-dev.dosomething.org": "https://identity-dev.dosomething.org/admin",
+
+  # Admin:
+  "admin.dosomething.org": "https://identity.dosomething.org/admin",
+  "admin-qa.dosomething.org": "https://identity-qa.dosomething.org/admin",
+  "admin-dev.dosomething.org": "https://identity-dev.dosomething.org/admin",
   
   # etc:
   "api.dosomething.org": "https://graphql.dosomething.org",


### PR DESCRIPTION
### What's this PR do?

This pull request scales down Rogue's web & queue instances and redirects those URLs (e.g. `activity.dosomething.org`) to Northstar's new unified admin interface!

### How should this be reviewed?

I'll apply these changes first in dev/QA, and then if all looks good make the change in production and set up the redirects!

### Any background context you want to provide?

🥍 

### Relevant tickets

References [Pivotal #176851318](https://www.pivotaltracker.com/story/show/176851318).

### Checklist

- [ ] This PR has been added to the relevant Pivotal card.
