### PR TITLE
Ghost Inspector Heroku Deploy Hook

### DIFF
--- a/applications/northstar/main.tf
+++ b/applications/northstar/main.tf
@@ -151,6 +151,12 @@ module "app" {
   with_newrelic          = coalesce(var.with_newrelic, var.environment == "production")
 }
 
+module "ghost_inspector_webhook" {
+  source       = "../../components/ghost_inspector_webhook"
+  name         = var.name
+  environment  = var.environment
+}
+
 module "iam_user" {
   source = "../../components/iam_app_user"
   name   = var.name

--- a/applications/phoenix/main.tf
+++ b/applications/phoenix/main.tf
@@ -122,6 +122,12 @@ module "database" {
   instance_class = var.environment == "production" ? "db.t2.medium" : "db.t2.micro"
 }
 
+module "ghost_inspector_webhook" {
+  source       = "../../components/ghost_inspector_webhook"
+  name         = var.name
+  environment  = var.environment
+}
+
 output "name" {
   value = var.name
 }

--- a/components/ghost_inspector_webhook/README.md
+++ b/components/ghost_inspector_webhook/README.md
@@ -1,0 +1,5 @@
+# Ghost Inspector Webhook
+
+This module creates a Heroku Post-Deploy Webhook which sends an HTTP request to Ghost Inspector to kick off the respective test suite per environment.
+
+For all options, see the [variables](https://github.com/DoSomething/infrastructure/blob/main/components/ghost_inspector_webhook/variables.tf) this module accepts & [outputs](https://github.com/DoSomething/infrastructure/blob/main/components/ghost_inspector_webhook/outputs.tf) it generates.

--- a/components/ghost_inspector_webhook/main.tf
+++ b/components/ghost_inspector_webhook/main.tf
@@ -1,0 +1,14 @@
+data "aws_ssm_parameter" "ghost_inspector_webhook" {
+  count = var.environment == "qa" ? 1 : 0
+  name  = "/ghost-inspector/webhooks/qa"
+}
+
+resource "heroku_addon" "webhook" {
+  count = var.environment == "qa" ? 1 : 0
+  app   = var.name
+  plan  = "deployhooks:http"
+
+  config = {
+    url = data.aws_ssm_parameter.ghost_inspector_webhook[0].value
+  }
+}

--- a/components/ghost_inspector_webhook/outputs.tf
+++ b/components/ghost_inspector_webhook/outputs.tf
@@ -1,0 +1,4 @@
+output "addon" {
+  description = "The Heroku webhook addon."
+  value       = heroku_addon.webhook
+}

--- a/components/ghost_inspector_webhook/variables.tf
+++ b/components/ghost_inspector_webhook/variables.tf
@@ -1,0 +1,7 @@
+variable "environment" {
+  description = "The environment for this application: development, qa, or production."
+}
+
+variable "name" {
+  description = "The name of the Heroku application resource to attach this webhook to."
+}


### PR DESCRIPTION
### What's this PR do?

This pull request adds a new "Ghost Inspector Webhook" component which configures a Heroku ([HTTP Post](https://devcenter.heroku.com/articles/deploy-hooks#http-post-hook)) Deploy Hook addon to automatically kick off our [Ghost Inspector QA suite](https://app.ghostinspector.com/suites/56980f16812f6dd51bc172f2) (using the webhook address stored in an AWS SSM Parameter) following an application deployment.

It's configured on the Phoenix & Northstar Heroku applications.

### How should this be reviewed?
👀 

### Any background context you want to provide?
This will help ensure that our team is on top of any test failures following a Pull Request being merged (and the app deploying to our QA environments).

Co-authored by @DFurnes 🎩 

### Relevant tickets

References [Pivotal #170523172](https://www.pivotaltracker.com/story/show/170523172).

### Checklist

- [x] This PR has been added to the relevant Pivotal card.
