### PR TITLE
Use 'premium-0' Redis add-ons on QA for better parity.

### DIFF
--- a/applications/northstar/main.tf
+++ b/applications/northstar/main.tf
@@ -132,7 +132,6 @@ module "app" {
   queue_scale = 1
 
   with_redis = true
-  redis_type = var.environment == "production" ? "premium-1" : "hobby-dev"
 
   papertrail_destination = var.papertrail_destination
   with_newrelic          = coalesce(var.with_newrelic, var.environment == "production")

--- a/applications/phoenix/main.tf
+++ b/applications/phoenix/main.tf
@@ -107,7 +107,6 @@ module "app" {
   queue_scale = 0
 
   with_redis = true
-  redis_type = var.environment == "production" ? "premium-1" : "hobby-dev"
 
   papertrail_destination = var.papertrail_destination
   with_newrelic          = coalesce(var.with_newrelic, var.environment == "production")

--- a/components/heroku_app/main.tf
+++ b/components/heroku_app/main.tf
@@ -124,9 +124,9 @@ locals {
     }
   }
 
-  # By default, use a paid Heroku Redis add-on plan, with 50MB storage and high
-  # availability, for production instances. Can be overridden with var.redis_type.
-  redis_default = var.environment == "production" ? "premium-0" : "hobby-dev"
+  # By default, use a paid Heroku Redis add-on plan, with 50MB storage and high availability
+  # for our production & QA instances. This can be overridden with var.redis_type.
+  redis_default = var.environment != "development" ? "premium-0" : "hobby-dev"
 
   # Decide which buildpacks to use based on our framework:
   buildpacks = {

--- a/dosomething-dev/main.tf
+++ b/dosomething-dev/main.tf
@@ -5,7 +5,6 @@ variable "papertrail_destination" {}
 variable "papertrail_destination_fastly" {}
 variable "northstar_pipeline" {}
 variable "phoenix_pipeline" {}
-variable "rogue_pipeline" {}
 
 terraform {
   backend "remote" {

--- a/dosomething-qa/main.tf
+++ b/dosomething-qa/main.tf
@@ -5,7 +5,6 @@ variable "papertrail_destination" {}
 variable "papertrail_destination_fastly" {}
 variable "northstar_pipeline" {}
 variable "phoenix_pipeline" {}
-variable "rogue_pipeline" {}
 
 terraform {
   backend "remote" {

--- a/dosomething/main.tf
+++ b/dosomething/main.tf
@@ -5,7 +5,6 @@ variable "papertrail_destination" {}
 variable "papertrail_destination_fastly" {}
 variable "northstar_pipeline" {}
 variable "phoenix_pipeline" {}
-variable "rogue_pipeline" {}
 
 terraform {
   backend "remote" {

--- a/shared/main.tf
+++ b/shared/main.tf
@@ -58,20 +58,12 @@ resource "heroku_pipeline" "northstar" {
   name = "northstar"
 }
 
-resource "heroku_pipeline" "rogue" {
-  name = "rogue"
-}
-
 resource "heroku_pipeline" "phoenix" {
   name = "phoenix"
 }
 
 output "northstar_pipeline" {
   value = "${heroku_pipeline.northstar.id}"
-}
-
-output "rogue_pipeline" {
-  value = "${heroku_pipeline.rogue.id}"
 }
 
 output "phoenix_pipeline" {


### PR DESCRIPTION
### What's this PR do?

This pull request updates our QA instances to use the base paid `premium-0` [Heroku Redis](https://elements.heroku.com/addons/heroku-redis) add-ons on QA, since that offers us better parity when testing changes on QA.

### How should this be reviewed?

👀

### Any background context you want to provide?

We don't want to be surprised again by something that works on QA & doesn't on prod! 💣

### Relevant tickets

References [Pivotal #177948981](https://www.pivotaltracker.com/story/show/177948981).

### Checklist

- [ ] This PR has been added to the relevant Pivotal card.
