### PR TITLE
Configure redirects from old Chompy domains.

### DIFF
--- a/redirects/main.tf
+++ b/redirects/main.tf
@@ -209,6 +209,14 @@ resource "fastly_service_v1" "redirects2" {
     name = "vote.dosomething.org"
   }
 
+  domain {
+    name = "importer.dosomething.org"
+  }
+
+  domain {
+    name = "importer-qa.dosomething.org"
+  }
+
   # Note: Fastly requires at least one backend per service,
   # so our AWS HAProxy instance is included here.
   backend {

--- a/redirects/redirects_table.vcl
+++ b/redirects/redirects_table.vcl
@@ -49,6 +49,10 @@ table redirects {
   "admin.dosomething.org": "https://identity.dosomething.org/admin",
   "admin-qa.dosomething.org": "https://identity-qa.dosomething.org/admin",
   "admin-dev.dosomething.org": "https://identity-dev.dosomething.org/admin",
+
+  # Chompy:
+  "importer.dosomething.org": "https://identity.dosomething.org/admin/imports",
+  "importer-qa.dosomething.org": "https://identity-qa.dosomething.org/admin/imports",
   
   # etc:
   "api.dosomething.org": "https://graphql.dosomething.org",


### PR DESCRIPTION
### What's this PR do?

This pull request configures redirects from `importer.` and `importer-qa.` domains to their new Northstar homes.

### How should this be reviewed?

👀

### Any background context you want to provide?

Now that this functionality lives within Northstar, we'll redirect the old URLs so links & bookmarks don't break! 🔀

### Relevant tickets

References [Pivotal #178699665](https://www.pivotaltracker.com/story/show/178699665).

### Checklist

- [ ] This PR has been added to the relevant Pivotal card.
